### PR TITLE
Statically link libstdc++ and libgcc.

### DIFF
--- a/cmake/FlowConfig.cmake
+++ b/cmake/FlowConfig.cmake
@@ -25,7 +25,7 @@ ExternalProject_Add(FoundationDB
 ExternalProject_Add_Step(FoundationDB server
         WORKING_DIRECTORY <SOURCE_DIR>
         EXCLUDE_FROM_MAIN 1
-        COMMAND make -j8 fdbserver fdbcli TLS_DISABLED=1)
+        COMMAND BOOSTDIR=${Boost_INCLUDE_DIRS} $(MAKE) fdbserver fdbcli TLS_DISABLED=1)
 ExternalProject_Add_StepTargets(FoundationDB server)
 
 ExternalProject_Get_Property(FoundationDB source_dir)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,6 +95,7 @@ if (APPLE)
             )
 else()
     target_link_libraries(fdbdoc PRIVATE rt dl)
+    target_link_libraries(fdbdoc PRIVATE -static-libstdc++ -static-libgcc)
 endif()
 
 set_target_properties(fdbdoc


### PR DESCRIPTION
This would help us make binaries work across different distributions.