### PR TITLE
Get rid of `std` usage from the metric reporter interface, which is a…

### DIFF
--- a/src/ConsoleMetric.actor.cpp
+++ b/src/ConsoleMetric.actor.cpp
@@ -168,12 +168,12 @@ ACTOR static Future<Void> publisher(ConsoleMetric* self) {
 	}
 }
 
-ConsoleMetric::ConsoleMetric(std::string& config) : IMetricReporter(config) {
+ConsoleMetric::ConsoleMetric(const char* config) : IMetricReporter(config) {
 	// Start the publishing loop
 	publisherHandle = publisher(this);
 }
 
-void ConsoleMetric::captureMetric(const std::string& metricName, int64_t metricValue, IMetricType metricType) {
+void ConsoleMetric::captureMetric(const char* metricName, int64_t metricValue, IMetricType metricType) {
 	if (metricStats.find(metricName) == metricStats.end()) {
 		// insert new stat
 		auto metric = MetricStat(metricName, metricType);

--- a/src/ConsoleMetric.h
+++ b/src/ConsoleMetric.h
@@ -26,6 +26,7 @@
 #include <ctime>
 #include <iostream>
 #include <string>
+#include <unordered_map>
 
 #include "flow/Arena.h"
 #include "flow/ThreadPrimitives.h"
@@ -71,16 +72,16 @@ private:
 class ConsoleMetric : public IMetricReporter, public IMetricReporterFactory<ConsoleMetric> {
 public:
 	// ctor
-	explicit ConsoleMetric(std::string& config);
+	explicit ConsoleMetric(const char* config);
 
 	// Since the metric reporter will have a static lifetime, it's OK to simply use the default dtor
 	~ConsoleMetric() override = default;
 
-	void captureMetric(const std::string& metricName, int64_t metricValue, IMetricType metricType) override;
+	void captureMetric(const char* metricName, int64_t metricValue, IMetricType metricType) override;
 	void publish();
 
 	// factory creator
-	static ConsoleMetric* CreatPluginImpl(std::string& config) { return new ConsoleMetric(config); }
+	static ConsoleMetric* CreatPluginImpl(const char* config) { return new ConsoleMetric(config); }
 
 	int64_t flushIntervalSeconds = 5; // default to aggregate and publish metrics over 5 seconds.
 private:

--- a/src/DocLayer.actor.cpp
+++ b/src/DocLayer.actor.cpp
@@ -879,10 +879,10 @@ int main(int argc, char** argv) {
 	g_network = newNet2(NetworkAddress(), false);
 
 	if (metricPluginPath && metricPluginPath[0]) {
-		DocumentLayer::metricReporter = IMetricReporter::init(metricPluginPath, metricReporterConfig);
+		DocumentLayer::metricReporter = IMetricReporter::init(metricPluginPath, metricReporterConfig.c_str());
 	} else {
 		// default to use `ConsoleMetric` plugin
-		DocumentLayer::metricReporter = new ConsoleMetric(metricReporterConfig);
+		DocumentLayer::metricReporter = new ConsoleMetric(metricReporterConfig.c_str());
 	}
 
 	if (proxyfrom.present()) {

--- a/src/IMetric.cpp
+++ b/src/IMetric.cpp
@@ -28,7 +28,7 @@
 
 static boost::dll::shared_library _loadedLib;
 
-IMetricReporter* IMetricReporter::init(const char* libPath, const std::string& libConfig) {
+IMetricReporter* IMetricReporter::init(const char* libPath, const char* libConfig) {
 	typedef IMetricReporter*(creator_t)(const std::string&);
 
 	// Code from Boost::DLL::import_alias begin
@@ -43,18 +43,18 @@ IMetricReporter* IMetricReporter::init(const char* libPath, const std::string& l
 	return reporter;
 }
 
-void IMetricReporter::captureCount(const std::string& metricName) {
+void IMetricReporter::captureCount(const char* metricName) {
 	captureMetric(metricName, 1, IMetricType::COUNT);
 }
-void IMetricReporter::captureTime(const std::string& metricName, int64_t metricValue) {
+void IMetricReporter::captureTime(const char* metricName, int64_t metricValue) {
 	captureMetric(metricName, metricValue, IMetricType::TIMER);
 }
-void IMetricReporter::captureGauge(const std::string& metricName, int64_t metricValue) {
+void IMetricReporter::captureGauge(const char* metricName, int64_t metricValue) {
 	captureMetric(metricName, metricValue, IMetricType::GAUGE);
 }
-void IMetricReporter::captureMeter(const std::string& metricName, int64_t metricValue) {
+void IMetricReporter::captureMeter(const char* metricName, int64_t metricValue) {
 	captureMetric(metricName, metricValue, IMetricType::METER);
 }
-void IMetricReporter::captureHistogram(const std::string& metricName, int64_t metricValue) {
+void IMetricReporter::captureHistogram(const char* metricName, int64_t metricValue) {
 	captureMetric(metricName, metricValue, IMetricType::HISTOGRAMS);
 }

--- a/src/IMetric.h
+++ b/src/IMetric.h
@@ -21,8 +21,7 @@
 #ifndef FDB_DOC_LAYER_IMETRIC_H
 #define FDB_DOC_LAYER_IMETRIC_H
 
-#include <string>
-#include <unordered_map>
+#include <cstdint>
 
 enum class IMetricType {
 	COUNT, // Measures how many times an event appears. E.g. total requests.
@@ -37,26 +36,26 @@ enum class IMetricType {
  */
 class IMetricReporter {
 public:
-	explicit IMetricReporter(std::string& config) : config(config){};
+	explicit IMetricReporter(const char* config) : config(config){};
 	// Move ctor
-	IMetricReporter(IMetricReporter&& reporter) noexcept : config(std::move(reporter.config)){};
+	IMetricReporter(IMetricReporter&& reporter) noexcept : config(reporter.config){};
 	IMetricReporter() = delete;
 	virtual ~IMetricReporter() = default;
 
-	virtual void captureMetric(const std::string& metricName, int64_t metricValue, IMetricType metricType) = 0;
+	virtual void captureMetric(const char* metricName, int64_t metricValue, IMetricType metricType) = 0;
 
-	void captureCount(const std::string& metricName);
-	void captureTime(const std::string& metricName, int64_t metricValue);
-	void captureGauge(const std::string& metricName, int64_t metricValue);
-	void captureMeter(const std::string& metricName, int64_t metricValue);
-	void captureHistogram(const std::string& metricName, int64_t metricValue);
+	void captureCount(const char* metricName);
+	void captureTime(const char* metricName, int64_t metricValue);
+	void captureGauge(const char* metricName, int64_t metricValue);
+	void captureMeter(const char* metricName, int64_t metricValue);
+	void captureHistogram(const char* metricName, int64_t metricValue);
 	/**
 	 * Load the dylib and call the static creator function defined to get a reference to the plugin.
 	 */
-	static IMetricReporter* init(const char* libPath, const std::string& libConfig);
+	static IMetricReporter* init(const char* libPath, const char* libConfig);
 
 protected:
-	std::string config;
+	const char* config;
 
 private:
 	static constexpr auto pluginCreatorName = "CreatPlugin";
@@ -70,7 +69,7 @@ private:
 template <class MetricReportImpl>
 class IMetricReporterFactory {
 public:
-	static MetricReportImpl* CreatPlugin(std::string& config) { return MetricReportImpl::CreatPluginImpl(config); }
+	static MetricReportImpl* CreatPlugin(const char* config) { return MetricReportImpl::CreatPluginImpl(config); }
 };
 
 #endif // FDB_DOC_LAYER_IMETRIC_H

--- a/src/IMetric.h
+++ b/src/IMetric.h
@@ -21,7 +21,7 @@
 #ifndef FDB_DOC_LAYER_IMETRIC_H
 #define FDB_DOC_LAYER_IMETRIC_H
 
-#include <cstdint>
+#include <stdint.h>
 
 enum class IMetricType {
 	COUNT, // Measures how many times an event appears. E.g. total requests.


### PR DESCRIPTION
… part of the effort to 'fix' builds in CentOS. With this change, we should be able to statically link libstdc++ without leaking symbols, which ultimately would allow the user provided dynamic metric report library to do whatever it wants.

This is part of the effort to fix #6 