### PR TITLE
Statically link libstdc++ and libgcc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,6 +95,7 @@ if (APPLE)
             )
 else()
     target_link_libraries(fdbdoc PRIVATE rt dl)
+    target_link_libraries(fdbdoc PRIVATE -static-libstdc++ -static-libgcc)
 endif()
 
 set_target_properties(fdbdoc


### PR DESCRIPTION
Statically linking libstdc++ known to cause issues with the plugin architecture. With the cleanup of plugin interface, #24, this change shouldn't cause any issues. But, I suspect we might have to revisit this in future when we end up having external plugins. For now, this change is important to make CentOS builds easier, #6.