### PR TITLE
Change collection name to Namespace

### DIFF
--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -824,9 +824,9 @@ ACTOR Future<WriteCmdResult> doInsertCmd(Namespace ns,
 		}
 		bson::BSONObj firstDoc = documents->front();
 
-		const char* ns = firstDoc.getField("ns").String().c_str();
-		const auto fullCollName = getDBCollectionPair(ns, std::make_pair("msg", "Bad coll name in index insert"));
-		WriteCmdResult result = wait(attemptIndexInsertion(firstDoc.getOwned(), ec, tr, fullCollName));
+		const char* collnsStr = firstDoc.getField("ns").String().c_str();
+		const auto collns = getDBCollectionPair(collnsStr, std::make_pair("msg", "Bad coll name in index insert"));
+		WriteCmdResult result = wait(attemptIndexInsertion(firstDoc.getOwned(), ec, tr, collns));
 		return result;
 	}
 

--- a/src/ExtMsg.h
+++ b/src/ExtMsg.h
@@ -71,11 +71,12 @@ struct ExtMsgQuery : ExtMsg, FastAllocated<ExtMsgQuery> {
 
 	ExtMsgHeader* header;
 	int32_t flags;
-	const char* fullCollectionName;
+	Namespace ns;
 	int32_t numberToSkip;
 	int32_t numberToReturn;
 	bson::BSONObj query;
 	bson::BSONObj returnFieldSelector;
+	bool isCmd;
 
 	std::string toString() override;
 	Future<Void> run(Reference<ExtConnection>) override;
@@ -135,7 +136,7 @@ struct ExtMsgUpdate : ExtMsg, FastAllocated<ExtMsgUpdate> {
 	enum Flags { UPSERT = 0x01, MULTI = 0x02 };
 
 	ExtMsgHeader* header;
-	const char* fullCollectionName;
+	Namespace ns;
 	int32_t flags;
 	bson::BSONObj selector;
 	bson::BSONObj update;
@@ -156,7 +157,7 @@ struct ExtMsgInsert : ExtMsg, FastAllocated<ExtMsgInsert> {
 
 	ExtMsgHeader* header;
 	int32_t flags;
-	const char* fullCollectionName;
+	Namespace ns;
 	std::list<bson::BSONObj> documents;
 
 	std::string toString() override;
@@ -171,7 +172,7 @@ struct ExtMsgGetMore : ExtMsg, FastAllocated<ExtMsgGetMore> {
 	enum { opcode = 2005 };
 
 	ExtMsgHeader* header;
-	const char* fullCollectionName;
+	Namespace ns;
 	int32_t numberToReturn;
 	int64_t cursorID;
 
@@ -187,7 +188,7 @@ struct ExtMsgDelete : ExtMsg, FastAllocated<ExtMsgDelete> {
 	enum { opcode = 2006 };
 
 	ExtMsgHeader* header;
-	const char* fullCollectionName;
+	Namespace ns;
 	int32_t flags;
 	std::vector<bson::BSONObj> selectors;
 
@@ -224,15 +225,15 @@ std::vector<std::string> staticValidateUpdateObject(bson::BSONObj update, bool m
 Future<WriteCmdResult> attemptIndexInsertion(bson::BSONObj const& firstDoc,
                                              Reference<ExtConnection> const& ec,
                                              Reference<DocTransaction> const& tr,
-                                             std::string const& fullCollectionName);
-Future<WriteCmdResult> doInsertCmd(const char* const& fullCollectionName,
+                                             Namespace const& ns);
+Future<WriteCmdResult> doInsertCmd(Namespace const& ns,
                                    std::list<bson::BSONObj>* const& documents,
                                    Reference<ExtConnection> const& ec);
-Future<WriteCmdResult> doDeleteCmd(const char* const& fullCollectionName,
+Future<WriteCmdResult> doDeleteCmd(Namespace const& ns,
                                    bool const& ordered,
                                    std::vector<bson::BSONObj>* const& selectors,
                                    Reference<ExtConnection> const& ec);
-Future<WriteCmdResult> doUpdateCmd(const char* const& fullCollectionName,
+Future<WriteCmdResult> doUpdateCmd(Namespace const& ns,
                                    bool const& ordered,
                                    std::vector<ExtUpdateCmd>* const& updateCmds,
                                    Reference<ExtConnection> const& ec);

--- a/src/ExtUtil.actor.cpp
+++ b/src/ExtUtil.actor.cpp
@@ -766,23 +766,21 @@ Optional<IdInfo> extractEncodedIdsFromUpdate(bson::BSONObj update) {
 	return Optional<IdInfo>();
 }
 
-Future<Reference<Plan>> getIndexesForCollectionPlan(std::string const& dbName,
-                                                    std::string const& collectionName,
+Future<Reference<Plan>> getIndexesForCollectionPlan(Namespace const& ns,
                                                     Reference<DocTransaction> tr,
                                                     Reference<MetadataManager> mm) {
-	std::string fullCollectionName = dbName + "." + collectionName;
-	Future<Reference<UnboundCollectionContext>> unbound = mm->indexesCollection(tr, dbName);
-	return map(unbound, [fullCollectionName](Reference<UnboundCollectionContext> unbound) {
-		Reference<IPredicate> pred = any_predicate("ns", ref(new EqPredicate(DataValue(fullCollectionName))), false);
+	std::string nsStr = ns.first + "." + ns.second;
+	Future<Reference<UnboundCollectionContext>> unbound = mm->indexesCollection(tr, ns.first);
+	return map(unbound, [nsStr](Reference<UnboundCollectionContext> unbound) {
+		Reference<IPredicate> pred = any_predicate("ns", ref(new EqPredicate(DataValue(nsStr))), false);
 		return FilterPlan::construct_filter_plan_no_pushdown(unbound, ref(new TableScanPlan(unbound)), pred);
 	});
 }
 
 Reference<Plan> getIndexesForCollectionPlan(Reference<UnboundCollectionContext> indexesCollection,
-                                            std::string const& dbName,
-                                            std::string const& collectionName) {
-	std::string fullCollectionName = dbName + "." + collectionName;
-	Reference<IPredicate> pred = any_predicate("ns", ref(new EqPredicate(DataValue(fullCollectionName))), false);
+                                            Namespace const& ns) {
+	std::string nsStr = ns.first + "." + ns.second;
+	Reference<IPredicate> pred = any_predicate("ns", ref(new EqPredicate(DataValue(nsStr))), false);
 	return FilterPlan::construct_filter_plan_no_pushdown(indexesCollection, ref(new TableScanPlan(indexesCollection)),
 	                                                     pred);
 }

--- a/src/ExtUtil.actor.h
+++ b/src/ExtUtil.actor.h
@@ -134,13 +134,10 @@ Optional<IdInfo> extractEncodedIds(bson::BSONObj obj);
  */
 Optional<IdInfo> extractEncodedIdsFromUpdate(bson::BSONObj update);
 
-Future<Reference<Plan>> getIndexesForCollectionPlan(std::string const& dbName,
-                                                    std::string const& collectionName,
+Future<Reference<Plan>> getIndexesForCollectionPlan(Namespace const& ns,
                                                     Reference<DocTransaction> tr,
                                                     Reference<MetadataManager> mm);
-Reference<Plan> getIndexesForCollectionPlan(Reference<UnboundCollectionContext> indexesCollection,
-                                            std::string const& dbName,
-                                            std::string const& collectionName);
+Reference<Plan> getIndexesForCollectionPlan(Reference<UnboundCollectionContext> indexesCollection, Namespace const& ns);
 Future<std::vector<bson::BSONObj>> getIndexesTransactionally(const Reference<Plan>& indexMetadataPlan,
                                                              const Reference<DocTransaction>& tr);
 

--- a/src/QLContext.actor.cpp
+++ b/src/QLContext.actor.cpp
@@ -446,7 +446,7 @@ struct SimpleIndexPlugin : IndexPlugin, ReferenceCounted<SimpleIndexPlugin>, Fas
 	void addref() override { ReferenceCounted<SimpleIndexPlugin>::addref(); }
 	void delref() override { ReferenceCounted<SimpleIndexPlugin>::delref(); }
 
-	// documentPath is fullCollectionName + docId
+	// documentPath is ns + docId
 	Future<Void> doIndexUpdate(Reference<DocTransaction> tr,
 	                           Reference<DocumentDeferred> dd,
 	                           DataKey documentPath) override {

--- a/src/QLPlan.h
+++ b/src/QLPlan.h
@@ -576,8 +576,8 @@ struct SkipPlan : ConcretePlan<SkipPlan> {
 };
 
 struct InsertPlan : ConcretePlan<InsertPlan> {
-	InsertPlan(std::vector<Reference<IInsertOp>> docs, Reference<MetadataManager> mm, std::string fullCollectionName)
-	    : docs(docs), mm(mm), fullCollectionName(fullCollectionName) {}
+	InsertPlan(std::vector<Reference<IInsertOp>> docs, Reference<MetadataManager> mm, Namespace ns)
+	    : docs(docs), mm(mm), ns(ns) {}
 
 	bson::BSONObj describe() override {
 		return BSON(
@@ -594,7 +594,7 @@ struct InsertPlan : ConcretePlan<InsertPlan> {
 private:
 	std::vector<Reference<IInsertOp>> docs;
 	Reference<MetadataManager> mm;
-	std::string fullCollectionName;
+	Namespace ns;
 };
 
 struct SortPlan : ConcretePlan<SortPlan> {
@@ -619,16 +619,14 @@ struct SortPlan : ConcretePlan<SortPlan> {
 struct IndexInsertPlan : ConcretePlan<IndexInsertPlan> {
 	Reference<IInsertOp> indexInsert;
 	bson::BSONObj indexObj;
-	std::string dbName;
-	std::string collectionName;
+	Namespace ns;
 	Reference<MetadataManager> mm;
 
 	IndexInsertPlan(Reference<IInsertOp> indexInsert,
 	                bson::BSONObj indexObj,
-	                std::string dbName,
-	                ::string collectionName,
+	                Namespace ns,
 	                Reference<MetadataManager> mm)
-	    : indexInsert(indexInsert), indexObj(indexObj), dbName(dbName), collectionName(collectionName), mm(mm) {}
+	    : indexInsert(indexInsert), indexObj(indexObj), ns(ns), mm(mm) {}
 
 	bson::BSONObj describe() override {
 		return BSON("type"
@@ -664,25 +662,18 @@ struct BuildIndexPlan : ConcretePlan<BuildIndexPlan> {
 };
 
 struct UpdateIndexStatusPlan : ConcretePlan<UpdateIndexStatusPlan> {
-	std::string dbName;
-	std::string collectionName;
+	Namespace ns;
 	Standalone<StringRef> encodedIndexId;
 	Reference<MetadataManager> mm;
 	std::string newStatus;
 	Optional<UID> buildId;
 
-	UpdateIndexStatusPlan(std::string const& dbName,
-	                      std::string const& collectionName,
+	UpdateIndexStatusPlan(Namespace const& ns,
 	                      Standalone<StringRef> encodedIndexId,
 	                      Reference<MetadataManager> mm,
 	                      std::string newStatus,
 	                      Optional<UID> buildId = Optional<UID>())
-	    : dbName(dbName),
-	      collectionName(collectionName),
-	      encodedIndexId(encodedIndexId),
-	      mm(mm),
-	      newStatus(newStatus),
-	      buildId(buildId) {}
+	    : ns(ns), encodedIndexId(encodedIndexId), mm(mm), newStatus(newStatus), buildId(buildId) {}
 
 	bson::BSONObj describe() override {
 		return BSON("type"


### PR DESCRIPTION
This should remove a lot of duplicate code to parse collection name. Using typed namespace instead of just string.