### PR TITLE
Adding Dockerfile with fdb-document-layer runtime.

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -22,11 +22,10 @@ FROM ubuntu:18.04
 # Install dependencies
 
 RUN apt-get update && \
-	apt-get install -y wget=1.19.4-1ubuntu2 \
-	dnsutils=1:9.11.3+dfsg-1ubuntu1.3 && \
+	apt-get install -y wget=1.19.4-1ubuntu2 && \
 	rm -r /var/lib/apt/lists/*
 
-# Install FoundationDB Binaries
+# Install FoundationDB Document Layer Binaries
 
 ARG FDB_DOC_VERSION
 ARG FDB_WEBSITE=https://www.foundationdb.org

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,0 +1,56 @@
+# Dockerfile
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM ubuntu:18.04
+
+# Install dependencies
+
+RUN apt-get update && \
+	apt-get install -y wget=1.19.4-1ubuntu2 \
+	dnsutils=1:9.11.3+dfsg-1ubuntu1.3 && \
+	rm -r /var/lib/apt/lists/*
+
+# Install FoundationDB Binaries
+
+ARG FDB_DOC_VERSION
+ARG FDB_WEBSITE=https://www.foundationdb.org
+
+WORKDIR /var/fdb/tmp
+RUN wget $FDB_WEBSITE/downloads/$FDB_DOC_VERSION/ubuntu/installers/fdb-document-layer_$FDB_DOC_VERSION-1_amd64.deb && \
+    dpkg -x fdb-document-layer_$FDB_DOC_VERSION-1_amd64.deb /var/fdb/tmp && \
+    rm fdb-document-layer_$FDB_DOC_VERSION-1_amd64.deb && \
+    mv /var/fdb/tmp/usr/sbin/fdbdoc /usr/bin && \
+    rm -rf /var/fdb/tmp
+
+WORKDIR /var/fdb
+
+# Document Layer is built with 6.0 FDB bindings. Hence, it doesn't work with old
+# versions of FDB. Until 6.1 is released, we don't need the multiversion client.
+# But, in the future we should support the multiversion client.
+ARG FDB_CLIENT_VERSION=6.0.15
+RUN wget $FDB_WEBSITE/downloads/$FDB_CLIENT_VERSION/linux/libfdb_c_$FDB_CLIENT_VERSION.so -O /usr/lib/libfdb_c.so
+
+COPY fdbdoc.bash scripts/
+RUN chmod u+x scripts/*.bash && mkdir -p logs
+
+CMD /var/fdb/scripts/fdbdoc.bash
+
+# Runtime Configuration Options
+ENV FDB_DOC_PORT 27016
+ENV FDB_NETWORKING_MODE container

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -11,7 +11,6 @@ The image relies on the following dependencies:
 
 *	bash
 *	wget
-*	dig
 *	glibc
 
 # Build Configuration

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -1,0 +1,52 @@
+# Overview
+
+This directory provides a Docker image for running FoundationDB Document Layer.
+It takes most of the scripts from FoundationDB Dockerfile.
+
+The image in this directory is based on Ubuntu 18.04, but the commands and
+scripts used to build it should be suitable for most other distros with small
+tweaks to the installation of dependencies.
+
+The image relies on the following dependencies:
+
+*	bash
+*	wget
+*	dig
+*	glibc
+
+# Build Configuration
+
+This image supports several build arguments for build-time configuration.
+
+### FDB_DOC_VERSION
+
+The version of FoundationDB Documnet Layer to install in the container. This is required.
+
+### FDB_WEBSITE
+
+The base URL for the FoundationDB website. The default is
+`https://www.foundationdb.org`.
+
+# Runtime Configuration
+
+This image supports several environment variables for run-time configuration.
+
+### FDB_DOC_PORT
+
+The port that FoundationDB Document Layer should bind to. The default is 27016. 
+
+### FDB_NETWORKING_MODE
+
+A networking mode that controls what address Document Layer listens on. If this
+is `container` (the default), then the server will listen on its public IP
+within the docker network, and will only be accessible from other containers.
+
+If this is `host`, then the server will listen on `127.0.0.1`, and will not be
+accessible from other containers. You should use `host` networking mode if you
+want to access your container from your host machine, and you should also
+map the port to the same port on your host machine when you run the container.
+
+### FDB_CLUSTER_FILE_CONTENTS
+
+This is a mandatory argument that contains the cluster file contents of the
+FoundationDB cluster, Document Layer needs to connect to.

--- a/packaging/docker/fdbdoc.bash
+++ b/packaging/docker/fdbdoc.bash
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+function setup_cluster_file() {
+	FDB_CLUSTER_FILE=${FDB_CLUSTER_FILE:-/etc/foundationdb/fdb.cluster}
+	mkdir -p $(dirname $FDB_CLUSTER_FILE)
+
+	if [[ -n "$FDB_CLUSTER_FILE_CONTENTS" ]]; then
+		echo "$FDB_CLUSTER_FILE_CONTENTS" > $FDB_CLUSTER_FILE
+    fi
+
+    if [ ! -f ${FDB_CLUSTER_FILE} ]; then
+        echo "Failed to locate cluster file at $FDB_CLUSTER_FILE" 1>&2
+        exit 1
+    fi
+}
+
+
+function setup_public_ip() {
+	if [[ "$FDB_NETWORKING_MODE" == "host" ]]; then
+		public_ip=127.0.0.1
+	elif [[ "$FDB_NETWORKING_MODE" == "container" ]]; then
+		public_ip=$(grep `hostname` /etc/hosts | sed -e "s/\s *`hostname`.*//")
+	else
+		echo "Unknown FDB Networking mode \"$FDB_NETWORKING_MODE\"" 1>&2
+		exit 1
+	fi
+
+	PUBLIC_IP=$public_ip
+}
+
+setup_public_ip
+setup_cluster_file
+
+echo "Starting FDB Document Layer on $PUBLIC_IP:$FDB_DOC_PORT"
+fdbdoc --listen_address $PUBLIC_IP:$FDB_DOC_PORT --logdir /var/fdb/logs


### PR DESCRIPTION
This is mostly stripped down version of Docker scripts used to create FoundationDB docker image.

Helps #13 