### PR TITLE
Cleaning up path and index key usage in IndexInfo

### DIFF
--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -949,9 +949,9 @@ std::vector<std::string> staticValidateUpdateObject(bson::BSONObj update, bool m
 	std::vector<std::string> bannedIndexFields;
 	bannedIndexFields.reserve(affectedFields.size() + prefixesOfAffectedFields.size());
 	for (const auto& s : affectedFields)
-		bannedIndexFields.push_back(encodeMaybeDotted(s));
+		bannedIndexFields.push_back(s);
 	for (const auto& s : prefixesOfAffectedFields)
-		bannedIndexFields.push_back(encodeMaybeDotted(s));
+		bannedIndexFields.push_back(s);
 	return bannedIndexFields;
 }
 

--- a/src/ExtOperator.actor.cpp
+++ b/src/ExtOperator.actor.cpp
@@ -144,9 +144,8 @@ REGISTER_VALUE_OPERATOR(ExtValueOperatorNot, "$not");
 struct ExtValueOperatorSize {
 	static const char* name;
 	static Reference<IPredicate> toPredicate(std::string const& unencoded_path, bson::BSONElement const& element) {
-		return ref(
-		    new AnyPredicate(ref(new ExtPathExpression(unencoded_path, false, false)),
-		                     ref(new ArraySizePredicate(element.Number()))));
+		return ref(new AnyPredicate(ref(new ExtPathExpression(unencoded_path, false, false)),
+		                            ref(new ArraySizePredicate(element.Number()))));
 	}
 };
 REGISTER_VALUE_OPERATOR(ExtValueOperatorSize, "$size");

--- a/src/ExtOperator.actor.cpp
+++ b/src/ExtOperator.actor.cpp
@@ -145,7 +145,7 @@ struct ExtValueOperatorSize {
 	static const char* name;
 	static Reference<IPredicate> toPredicate(std::string const& unencoded_path, bson::BSONElement const& element) {
 		return ref(
-		    new AnyPredicate(ref(new ExtPathExpression(StringRef(encodeMaybeDotted(unencoded_path)), false, false)),
+		    new AnyPredicate(ref(new ExtPathExpression(unencoded_path, false, false)),
 		                     ref(new ArraySizePredicate(element.Number()))));
 	}
 };

--- a/src/ExtUtil.actor.cpp
+++ b/src/ExtUtil.actor.cpp
@@ -470,7 +470,7 @@ bool is_literal_match(bson::BSONObj const& obj) {
 Reference<IPredicate> any_predicate(std::string unencoded_path, Reference<IPredicate> pred, bool inElemMatch) {
 	if (unencoded_path.empty())
 		return pred;
-	return ref(new AnyPredicate(ref(new ExtPathExpression(StringRef(encodeMaybeDotted(unencoded_path)), true,
+	return ref(new AnyPredicate(ref(new ExtPathExpression(unencoded_path, true,
 	                                                      !inElemMatch && pred->wantsNulls())),
 	                            pred));
 }

--- a/src/ExtUtil.actor.cpp
+++ b/src/ExtUtil.actor.cpp
@@ -470,9 +470,8 @@ bool is_literal_match(bson::BSONObj const& obj) {
 Reference<IPredicate> any_predicate(std::string unencoded_path, Reference<IPredicate> pred, bool inElemMatch) {
 	if (unencoded_path.empty())
 		return pred;
-	return ref(new AnyPredicate(ref(new ExtPathExpression(unencoded_path, true,
-	                                                      !inElemMatch && pred->wantsNulls())),
-	                            pred));
+	return ref(
+	    new AnyPredicate(ref(new ExtPathExpression(unencoded_path, true, !inElemMatch && pred->wantsNulls())), pred));
 }
 
 Reference<IPredicate> eq_predicate(const bson::BSONElement& el, const std::string& prefix) {

--- a/src/MetadataManager.actor.cpp
+++ b/src/MetadataManager.actor.cpp
@@ -40,7 +40,7 @@ Future<uint64_t> getMetadataVersion(Reference<DocTransaction> tr, Reference<Dire
 
 std::string describeIndex(std::vector<std::pair<std::string, int>> indexKeys) {
 	std::string ret = "index: ";
-	for (const auto &indexKey : indexKeys) {
+	for (const auto& indexKey : indexKeys) {
 		ret += format("{%s:%d}, ", indexKey.first.c_str(), indexKey.second);
 	}
 	ret.resize(ret.length() - 2);

--- a/src/MetadataManager.actor.cpp
+++ b/src/MetadataManager.actor.cpp
@@ -40,15 +40,8 @@ Future<uint64_t> getMetadataVersion(Reference<DocTransaction> tr, Reference<Dire
 
 std::string describeIndex(std::vector<std::pair<std::string, int>> indexKeys) {
 	std::string ret = "index: ";
-	for (auto p : indexKeys) {
-		std::string keyStr;
-		DataKey key = DataKey::decode_bytes(StringRef(p.first));
-		for (int i = 0; i < key.size(); i++) {
-			keyStr.append(DataValue::decode_key_part(key[i]).getString());
-			if (i < key.size() - 1)
-				keyStr.append(".");
-		}
-		ret += format("{%s:%d}, ", keyStr.c_str(), p.second);
+	for (const auto &indexKey : indexKeys) {
+		ret += format("{%s:%d}, ", indexKey.first.c_str(), indexKey.second);
 	}
 	ret.resize(ret.length() - 2);
 	return ret;
@@ -72,7 +65,7 @@ IndexInfo MetadataManager::indexInfoFromObj(const bson::BSONObj& indexObj, Refer
 	bool isUniqueIndex = indexObj.hasField("unique") ? indexObj.getBoolField("unique") : false;
 	for (auto i = keyObj.begin(); i.more();) {
 		auto e = i.next();
-		indexKeys.emplace_back(encodeMaybeDotted(e.fieldName()), (int)e.Number());
+		indexKeys.emplace_back(e.fieldName(), (int)e.Number());
 	}
 	if (verboseLogging) {
 		TraceEvent("BD_getAndAddIndexes").detail("AddingIndex", describeIndex(indexKeys));

--- a/src/QLContext.actor.cpp
+++ b/src/QLContext.actor.cpp
@@ -592,17 +592,15 @@ QueryContext::QueryContext(class Reference<ITDoc> layers, Reference<DocTransacti
 void QueryContext::addIndex(IndexInfo index) {
 	if (index.size() == 1) {
 		self->layers = Reference<ITDoc>(new SimpleIndexPlugin(
-		    self->prefix, index,
-		    Reference<IExpression>(new ExtPathExpression(index.indexKeys[0].first, true, true)),
+		    self->prefix, index, Reference<IExpression>(new ExtPathExpression(index.indexKeys[0].first, true, true)),
 		    self->layers));
 	} else {
 		std::vector<std::pair<Reference<IExpression>, int>> exprs(index.size());
-		std::transform(index.indexKeys.begin(), index.indexKeys.end(), exprs.begin(),
-		               [](std::pair<std::string, int> index_pair) {
-			               return std::make_pair(
-			                   Reference<IExpression>(new ExtPathExpression(index_pair.first, true, true)),
-			                   index_pair.second);
-		               });
+		std::transform(
+		    index.indexKeys.begin(), index.indexKeys.end(), exprs.begin(), [](std::pair<std::string, int> index_pair) {
+			    return std::make_pair(Reference<IExpression>(new ExtPathExpression(index_pair.first, true, true)),
+			                          index_pair.second);
+		    });
 		self->layers = Reference<ITDoc>(new CompoundIndexPlugin(self->prefix, index, exprs, self->layers));
 	}
 }

--- a/src/QLContext.actor.cpp
+++ b/src/QLContext.actor.cpp
@@ -773,12 +773,12 @@ Future<Standalone<StringRef>> BsonContext::getKeyEncodedId() {
 }
 
 IndexInfo::IndexInfo(std::string indexName,
-                     std::vector<std::pair<std::string, int>> newIndexKeys,
+                     std::vector<std::pair<std::string, int>> indexKeys,
                      Reference<UnboundCollectionContext> collectionCx,
                      IndexStatus status,
                      Optional<UID> buildId,
                      bool isUniqueIndex)
-    : indexName(indexName), indexKeys(newIndexKeys), status(status), buildId(buildId), isUniqueIndex(isUniqueIndex) {
+    : indexName(indexName), indexKeys(indexKeys), status(status), buildId(buildId), isUniqueIndex(isUniqueIndex) {
 	encodedIndexName = DataValue(indexName, DVTypeCode::STRING).encode_key_part();
 	indexCx = collectionCx->getIndexesContext()->getSubContext(encodedIndexName);
 	multikey = true;

--- a/src/QLContext.h
+++ b/src/QLContext.h
@@ -359,7 +359,7 @@ struct IndexInfo {
 	bool isUniqueIndex;
 
 	IndexInfo(std::string indexName,
-	          std::vector<std::pair<std::string, int>> newIndexKeys,
+	          std::vector<std::pair<std::string, int>> indexKeys,
 	          Reference<struct UnboundCollectionContext> collectionCx,
 	          IndexStatus status,
 	          Optional<UID> buildId = Optional<UID>(),

--- a/src/QLContext.h
+++ b/src/QLContext.h
@@ -376,8 +376,7 @@ struct IndexComparator {
 struct UnboundCollectionContext : ReferenceCounted<UnboundCollectionContext>, FastAllocated<UnboundCollectionContext> {
 	UnboundCollectionContext(Reference<DirectorySubspace> collectionDirectory,
 	                         Reference<DirectorySubspace> metadataDirectory)
-	    : collectionDirectory(collectionDirectory),
-	      metadataDirectory(metadataDirectory) {
+	    : collectionDirectory(collectionDirectory), metadataDirectory(metadataDirectory) {
 		cx = Reference<UnboundQueryContext>(new UnboundQueryContext())->getSubContext(collectionDirectory->key());
 	}
 

--- a/src/QLContext.h
+++ b/src/QLContext.h
@@ -359,7 +359,7 @@ struct IndexInfo {
 	bool isUniqueIndex;
 
 	IndexInfo(std::string indexName,
-	          std::vector<std::pair<std::string, int>> indexKeys,
+	          std::vector<std::pair<std::string, int>> newIndexKeys,
 	          Reference<struct UnboundCollectionContext> collectionCx,
 	          IndexStatus status,
 	          Optional<UID> buildId = Optional<UID>(),
@@ -377,8 +377,7 @@ struct UnboundCollectionContext : ReferenceCounted<UnboundCollectionContext>, Fa
 	UnboundCollectionContext(Reference<DirectorySubspace> collectionDirectory,
 	                         Reference<DirectorySubspace> metadataDirectory)
 	    : collectionDirectory(collectionDirectory),
-	      metadataDirectory(metadataDirectory),
-	      bannedFieldNames(Optional<std::set<std::string>>()) {
+	      metadataDirectory(metadataDirectory) {
 		cx = Reference<UnboundQueryContext>(new UnboundQueryContext())->getSubContext(collectionDirectory->key());
 	}
 
@@ -390,18 +389,16 @@ struct UnboundCollectionContext : ReferenceCounted<UnboundCollectionContext>, Fa
 	      cx(Reference<UnboundQueryContext>::addRef(other.cx.getPtr())),
 	      bannedFieldNames(other.bannedFieldNames) {}
 
-	Optional<IndexInfo> getSimpleIndex(StringRef simple_index_map_key);
-	Optional<IndexInfo> getCompoundIndex(IndexInfo prefix, StringRef encoded_next_index_key);
-	void setBannedFieldNames(Optional<std::vector<std::string>> bannedFns) {
-		bannedFieldNames = bannedFns.present() ? std::set<std::string>(bannedFns.get().begin(), bannedFns.get().end())
-		                                       : Optional<std::set<std::string>>();
+	Optional<IndexInfo> getSimpleIndex(std::string simple_index_map_key);
+	Optional<IndexInfo> getCompoundIndex(IndexInfo prefix, std::string encoded_next_index_key);
+	void setBannedFieldNames(std::vector<std::string> bannedFns) {
+		bannedFieldNames = std::set<std::string>(bannedFns.begin(), bannedFns.end());
 	}
 	FDB::Key getVersionKey();
 	Reference<struct CollectionContext> bindCollectionContext(Reference<DocTransaction> tr);
 	void addIndex(IndexInfo index);
 	Key getIndexesSubspace();
 	Reference<UnboundQueryContext> getIndexesContext(); // FIXME: Remove this method
-	void filterIndexesWithBannedFieldnames(std::vector<std::string> const& bannedFieldNames);
 	std::string databaseName();
 	std::string collectionName();
 
@@ -418,7 +415,7 @@ struct UnboundCollectionContext : ReferenceCounted<UnboundCollectionContext>, Fa
 	std::vector<IndexInfo> knownIndexes;
 
 private:
-	Optional<std::set<std::string>> bannedFieldNames;
+	std::set<std::string> bannedFieldNames;
 };
 
 struct CollectionContext : ReferenceCounted<CollectionContext>, FastAllocated<CollectionContext> {

--- a/src/QLExpression.h
+++ b/src/QLExpression.h
@@ -50,9 +50,10 @@ struct IExpression {
 	/**
 	 * Return the name of the index which, if it exists, indexes by the values of this expression
 	 */
-	virtual Standalone<StringRef> get_index_key() const { return StringRef(); }
+	virtual std::string get_index_key() const { return {}; }
 };
 
+std::string encodeMaybeDotted(std::string fieldname);
 /**
  * This expression implements a MongoDB dot-separated path expansion (it returns all subdocuments
  * patching the given path, expanding arrays as necessary).
@@ -60,21 +61,24 @@ struct IExpression {
 struct ExtPathExpression : IExpression, ReferenceCounted<ExtPathExpression>, FastAllocated<ExtPathExpression> {
 
 	Standalone<StringRef> path;
+	std::string strPath;
 	bool expandLastArray;
 	bool imputeNulls;
 
 	void addref() { ReferenceCounted<ExtPathExpression>::addref(); }
 	void delref() { ReferenceCounted<ExtPathExpression>::delref(); }
 
-	std::string toString() const override { return "ExtPath(" + FDB::printable(path) + ")"; }
+	std::string toString() const override { return "ExtPath(" + strPath + ")"; }
 
-	ExtPathExpression(Standalone<StringRef> const& path, bool const& expandLastArray, bool const& imputeNulls)
-	    : path(path), expandLastArray(expandLastArray), imputeNulls(imputeNulls) {}
+	ExtPathExpression(std::string const& strPath, bool const& expandLastArray, bool const& imputeNulls)
+		: strPath(strPath), expandLastArray(expandLastArray), imputeNulls(imputeNulls) {
+		path = StringRef(encodeMaybeDotted(strPath));
+	}
 
 	GenFutureStream<Reference<IReadContext>> evaluate(Reference<IReadContext> const& document) override;
 
-	Standalone<StringRef> get_index_key() const override {
-		return expandLastArray ? path : Standalone<StringRef>();
+	std::string get_index_key() const override {
+		return expandLastArray ? strPath : std::string();
 	} // FIXME: a.$n?.b.$n
 };
 

--- a/src/QLExpression.h
+++ b/src/QLExpression.h
@@ -71,7 +71,7 @@ struct ExtPathExpression : IExpression, ReferenceCounted<ExtPathExpression>, Fas
 	std::string toString() const override { return "ExtPath(" + strPath + ")"; }
 
 	ExtPathExpression(std::string const& strPath, bool const& expandLastArray, bool const& imputeNulls)
-		: strPath(strPath), expandLastArray(expandLastArray), imputeNulls(imputeNulls) {
+	    : strPath(strPath), expandLastArray(expandLastArray), imputeNulls(imputeNulls) {
 		path = StringRef(encodeMaybeDotted(strPath));
 	}
 

--- a/src/QLPlan.actor.cpp
+++ b/src/QLPlan.actor.cpp
@@ -430,7 +430,7 @@ ACTOR static Future<Void> deduplicateIndexStream(PlanCheckpoint* checkpoint,
 	state Deque<std::pair<Reference<ScanReturnedContext>, Future<bool>>> futures;
 	state std::pair<Reference<ScanReturnedContext>, Future<bool>> p;
 	state std::vector<Reference<IExpression>> exprs;
-	for (const auto &indexKey : self.indexKeys)
+	for (const auto& indexKey : self.indexKeys)
 		exprs.push_back(Reference<IExpression>(new ExtPathExpression(indexKey.first, true, true)));
 	state PlanCheckpoint::FlowControlLock* flowControlLock = checkpoint->getDocumentFinishedLock();
 	try {

--- a/test/correctness/mongo_model.py
+++ b/test/correctness/mongo_model.py
@@ -518,6 +518,9 @@ class MongoCollection(object):
     def ensure_index(self, fake_variable):
         pass
 
+    def create_index(self, _):
+        pass
+
     @staticmethod
     def check_fields(update):
         affected_fields = set()


### PR DESCRIPTION
This PR tries to clean up the representation of index keys in `IndexInfo`. We do store them as encoded strings, which makes it very confusing. First of all, all the code that needs to use `IndexInfo` gets the key as unencoded, so every function call and search code encoded just before. In addition to this, we store these encoded bytes in `std::string`, making it confusing which bits are encoded and which are plain field names. This code is hiding few bugs related to indexes.

This is just cleanup, doesn't fix any issue, but should help - #40, #38, #35 and #39