### PR TITLE
Fixing compound index prefix match

### DIFF
--- a/src/QLContext.actor.cpp
+++ b/src/QLContext.actor.cpp
@@ -708,7 +708,7 @@ Optional<IndexInfo> UnboundCollectionContext::getCompoundIndex(std::vector<std::
 	auto indexV = simpleIndexMap.find(prefix[0]);
 	ASSERT(indexV != simpleIndexMap.end());
 	for (IndexInfo index : indexV->second) {
-		if (index.hasPrefix(prefix)) {
+		if (index.size() > prefix.size() && index.hasPrefix(prefix)) {
 			if (index.indexKeys[prefix.size()].first == nextIndexKey) {
 				return index;
 			}

--- a/src/QLContext.actor.cpp
+++ b/src/QLContext.actor.cpp
@@ -701,14 +701,15 @@ Optional<IndexInfo> UnboundCollectionContext::getSimpleIndex(std::string simpleI
 	}
 }
 
-Optional<IndexInfo> UnboundCollectionContext::getCompoundIndex(IndexInfo prefix, std::string nextIndexKey) {
+Optional<IndexInfo> UnboundCollectionContext::getCompoundIndex(std::vector<std::string> const& prefix,
+                                                               std::string nextIndexKey) {
 	if (bannedFieldNames.find(nextIndexKey) != bannedFieldNames.end())
 		return Optional<IndexInfo>();
-	auto indexV = simpleIndexMap.find(prefix.indexKeys[0].first);
+	auto indexV = simpleIndexMap.find(prefix[0]);
 	ASSERT(indexV != simpleIndexMap.end());
 	for (IndexInfo index : indexV->second) {
-		if (index.size() > prefix.size() && index.hasPrefix(prefix)) {
-			if (index.indexKeys[prefix.indexKeys.size()].first == nextIndexKey) {
+		if (index.hasPrefix(prefix)) {
+			if (index.indexKeys[prefix.size()].first == nextIndexKey) {
 				return index;
 			}
 		}
@@ -785,9 +786,12 @@ IndexInfo::IndexInfo(std::string indexName,
 }
 
 // SOMEDAY: If we store the index name as Tuple encoded bytes, prefix comparision would be faster
-bool IndexInfo::hasPrefix(IndexInfo const& other) {
-	for (int i = 0; i < other.size(); i++) {
-		if (indexKeys[i] != other.indexKeys[i]) {
+bool IndexInfo::hasPrefix(std::vector<std::string> const& prefix) {
+	if (prefix.size() > indexKeys.size())
+		return false;
+
+	for (int i = 0; i < prefix.size(); i++) {
+		if (indexKeys[i].first != prefix[i]) {
 			return false;
 		}
 	}

--- a/src/QLContext.h
+++ b/src/QLContext.h
@@ -365,7 +365,7 @@ struct IndexInfo {
 	          Optional<UID> buildId = Optional<UID>(),
 	          bool isUniqueIndex = false);
 	IndexInfo() : status(IndexStatus::INVALID) {}
-	bool hasPrefix(IndexInfo const& other);
+	bool hasPrefix(std::vector<std::string> const& prefix);
 	int size() const { return static_cast<int>(indexKeys.size()); }
 };
 
@@ -389,7 +389,7 @@ struct UnboundCollectionContext : ReferenceCounted<UnboundCollectionContext>, Fa
 	      bannedFieldNames(other.bannedFieldNames) {}
 
 	Optional<IndexInfo> getSimpleIndex(std::string simple_index_map_key);
-	Optional<IndexInfo> getCompoundIndex(IndexInfo prefix, std::string encoded_next_index_key);
+	Optional<IndexInfo> getCompoundIndex(std::vector<std::string> const& prefix, std::string nextIndexKey);
 	void setBannedFieldNames(std::vector<std::string> bannedFns) {
 		bannedFieldNames = std::set<std::string>(bannedFns.begin(), bannedFns.end());
 	}

--- a/src/QLPlan.h
+++ b/src/QLPlan.h
@@ -246,8 +246,9 @@ struct IndexScanPlan : ConcretePlan<IndexScanPlan> {
 	IndexScanPlan(Reference<UnboundCollectionContext> cx,
 	              IndexInfo index,
 	              Optional<std::string> begin,
-	              Optional<std::string> end)
-	    : cx(cx), index(index), begin(begin), end(end) {}
+	              Optional<std::string> end,
+	              std::vector<std::string> matchedPrefix)
+	    : cx(cx), index(index), begin(begin), end(end), matchedPrefix(matchedPrefix) {}
 	bson::BSONObj describe() override {
 		std::string bound_begin = begin.present() ? FDB::printable(begin.get()) : "-inf";
 		std::string bound_end = end.present() ? FDB::printable(end.get()) : "+inf";
@@ -270,10 +271,13 @@ struct IndexScanPlan : ConcretePlan<IndexScanPlan> {
 
 private:
 	Reference<UnboundCollectionContext> cx;
-	Standalone<StringRef> index_name;
 	IndexInfo index;
 	Optional<std::string> begin;
 	Optional<std::string> end;
+
+	// Matched index not necessarily the exact match. This plan could simply use prefix of index.
+	// For now, index direction is not honored by Doc Layer, probably SOMEDAY
+	std::vector<std::string> matchedPrefix;
 };
 
 struct PrimaryKeyLookupPlan : ConcretePlan<PrimaryKeyLookupPlan> {

--- a/test/correctness/unit/planner_tests.py
+++ b/test/correctness/unit/planner_tests.py
@@ -176,6 +176,16 @@ def test_simple_9():
 def test_compound_1():
     return ("Basic Compound Index", [Index("compound", [("a", 1), ("b", 1)])], {
         '$and': [{
+            'a': 1
+        }, {
+            'b': 1
+        }]
+    }, Predicates.no_table_scan_no_filter)
+
+
+def test_compound_11():
+    return ("Basic Compound Index", [Index("compound", [("a", 1), ("b", 1)])], {
+        '$and': [{
             'b': 1
         }, {
             'a': 1
@@ -285,7 +295,60 @@ def test_compound_7():
              }, lambda e: Predicates.only_index_named("short", e))
 
 
+def test_compound_8():
+    return ("Compound index matching exact index",
+            [Index("a", [("a", 1)]),
+             Index("ab", [("a", 1), ("b", 1)]),
+             Index("abc", [("a", 1), ("b", 1), ("c", 1)]),
+             Index("abcde", [("a", 1), ("b", 1), ("c", 1), ("d", 1), ("e", 1)])], {
+                '$and': [{
+                    'a': 1
+                }, {
+                    'b': 1
+                }, {
+                    'c': 1
+                }]
+            }, lambda e: Predicates.only_index_named("abc", e) and Predicates.no_table_scan_no_filter(e))
+
+
+def test_compound_9():
+    return ("Compound index matching longest prefix",
+            [Index("a", [("a", 1)]),
+             Index("ab", [("a", 1), ("b", 1)]),
+             Index("abc", [("a", 1), ("b", 1), ("c", 1)]),
+             Index("abcde", [("a", 1), ("b", 1), ("c", 1), ("d", 1), ("e", 1)])], {
+                '$and': [{
+                    'a': 1
+                }, {
+                    'b': 1
+                }, {
+                    'c': 1
+                }, {
+                    'd': 1
+                }]
+            }, lambda e: Predicates.only_index_named("abcde", e) and Predicates.no_table_scan_no_filter(e))
+
+
+def test_compound_10():
+    return ("Compound index matching dscontinuous index prefix",
+            [Index("a", [("a", 1)]),
+             Index("ab", [("a", 1), ("b", 1)]),
+             Index("abc", [("a", 1), ("b", 1), ("c", 1)]),
+             Index("abcde", [("a", 1), ("b", 1), ("c", 1), ("d", 1), ("e", 1)])], {
+                '$and': [{
+                    'a': 1
+                }, {
+                    'b': 1
+                }, {
+                    'c': 1
+                }, {
+                    'e': 1
+                }]
+            }, lambda e: Predicates.only_index_named("abc", e) and Predicates.no_table_scan(e))
+
+
 tests = [globals()[f] for f in dir() if f.startswith("test_")]
+
 
 def test(collection, t):
     (name, indexes, query, condition) = t


### PR DESCRIPTION
Query planner matches compound indexes incrementally. Bug exists in this part of the code such that, if the predicate is on `A and B` and if it matches first with index `A_C`, then later stages of the incremental check instead of looking for index match `A_B`, it looks for `A_C_B`. This patch fixes that issue.

This fixes #46 and also fixes #38 