### PR TITLE
Resolves #51: Delete command shouldn't create new collection.

### DIFF
--- a/src/ExtCmd.h
+++ b/src/ExtCmd.h
@@ -50,9 +50,4 @@ struct ExtCmd : IDispatched<ExtCmd,
 	const char* Cmd::name = Key;                                                                                       \
 	REGISTER_COMMAND(ExtCmd, Cmd, name, call);
 
-Future<Reference<UnboundCollectionContext>> getCollectionContextForCommand(Reference<ExtConnection> ec,
-                                                                           Reference<ExtMsgQuery> query,
-                                                                           Reference<DocTransaction> dtr,
-                                                                           bool allowSystemNamespace);
-
 #endif /* _EXT_CMD_H_ */

--- a/src/MetadataManager.actor.cpp
+++ b/src/MetadataManager.actor.cpp
@@ -82,7 +82,7 @@ IndexInfo MetadataManager::indexInfoFromObj(const bson::BSONObj& indexObj, Refer
 }
 
 ACTOR static Future<std::pair<Reference<UnboundCollectionContext>, uint64_t>>
-constructContext(Namespace ns, Reference<DocTransaction> tr, DocumentLayer* docLayer, bool includeIndex = true) {
+constructContext(Namespace ns, Reference<DocTransaction> tr, DocumentLayer* docLayer, bool includeIndex, bool createIfAbsent) {
 	try {
 		// The initial set of directory reads take place in a separate transaction with the same read version as `tr'.
 		// This hopefully prevents us from accidentally RYWing a directory that `tr' itself created, and then adding it
@@ -135,6 +135,9 @@ constructContext(Namespace ns, Reference<DocTransaction> tr, DocumentLayer* docL
 		if (!rootExists)
 			throw doclayer_metadata_changed();
 
+		if (!createIfAbsent)
+			throw collection_not_found();
+
 		// NB: These directory creations are not parallelized deliberately, because it is unsafe to create directories
 		// in parallel with the same transaction in the Flow directory layer.
 		state Reference<DirectorySubspace> tcollectionDirectory =
@@ -157,7 +160,8 @@ constructContext(Namespace ns, Reference<DocTransaction> tr, DocumentLayer* docL
 ACTOR static Future<Reference<UnboundCollectionContext>> assembleCollectionContext(Reference<DocTransaction> tr,
                                                                                    Namespace ns,
                                                                                    Reference<MetadataManager> self,
-                                                                                   bool includeIndex = true) {
+                                                                                   bool includeIndex,
+                                                                                   bool createIfAbsent) {
 	if (self->contexts.size() > 100)
 		self->contexts.clear();
 
@@ -165,7 +169,7 @@ ACTOR static Future<Reference<UnboundCollectionContext>> assembleCollectionConte
 
 	if (match == self->contexts.end()) {
 		std::pair<Reference<UnboundCollectionContext>, uint64_t> unboundPair =
-		    wait(constructContext(ns, tr, self->docLayer, includeIndex));
+		    wait(constructContext(ns, tr, self->docLayer, includeIndex, createIfAbsent));
 
 		// Here and below don't pollute the cache if we just created the directory, since this transaction might
 		// not commit.
@@ -185,7 +189,7 @@ ACTOR static Future<Reference<UnboundCollectionContext>> assembleCollectionConte
 		uint64_t version = wait(getMetadataVersion(tr, oldUnbound->metadataDirectory));
 		if (version != oldVersion) {
 			std::pair<Reference<UnboundCollectionContext>, uint64_t> unboundPair =
-			    wait(constructContext(ns, tr, self->docLayer, includeIndex));
+			    wait(constructContext(ns, tr, self->docLayer, includeIndex, createIfAbsent));
 			if (unboundPair.second != -1) {
 				// Create the iterator again instead of making the previous value state, because the map could have
 				// changed during the previous wait. Either way, replace it with ours (can no longer optimize this by
@@ -209,17 +213,18 @@ ACTOR static Future<Reference<UnboundCollectionContext>> assembleCollectionConte
 Future<Reference<UnboundCollectionContext>> MetadataManager::getUnboundCollectionContext(Reference<DocTransaction> tr,
                                                                                          Namespace const& ns,
                                                                                          bool allowSystemNamespace,
-                                                                                         bool includeIndex) {
+                                                                                         bool includeIndex,
+                                                                                         bool createIfAbsent) {
 	if (!allowSystemNamespace && startsWith(ns.second.c_str(), "system."))
 		throw write_system_namespace();
-	return assembleCollectionContext(tr, ns, Reference<MetadataManager>::addRef(this), includeIndex);
+	return assembleCollectionContext(tr, ns, Reference<MetadataManager>::addRef(this), includeIndex, createIfAbsent);
 }
 
 Future<Reference<UnboundCollectionContext>> MetadataManager::refreshUnboundCollectionContext(
     Reference<UnboundCollectionContext> cx,
     Reference<DocTransaction> tr) {
 	return assembleCollectionContext(tr, std::make_pair(cx->databaseName(), cx->collectionName()),
-	                                 Reference<MetadataManager>::addRef(this), false);
+	                                 Reference<MetadataManager>::addRef(this), false, false);
 }
 
 ACTOR static Future<Void> buildIndex_impl(bson::BSONObj indexObj,

--- a/src/MetadataManager.h
+++ b/src/MetadataManager.h
@@ -36,7 +36,8 @@ struct MetadataManager : ReferenceCounted<MetadataManager>, NonCopyable {
 	Future<Reference<UnboundCollectionContext>> getUnboundCollectionContext(Reference<DocTransaction> tr,
 	                                                                        Namespace const& ns,
 	                                                                        bool allowSystemNamespace = false,
-	                                                                        bool includeIndex = true);
+	                                                                        bool includeIndex = true,
+	                                                                        bool createIfAbsent = true);
 	Future<Reference<UnboundCollectionContext>> refreshUnboundCollectionContext(Reference<UnboundCollectionContext> cx,
 	                                                                            Reference<DocTransaction> tr);
 

--- a/src/MetadataManager.h
+++ b/src/MetadataManager.h
@@ -37,7 +37,7 @@ struct MetadataManager : ReferenceCounted<MetadataManager>, NonCopyable {
 	                                                                        Namespace const& ns,
 	                                                                        bool allowSystemNamespace = false,
 	                                                                        bool includeIndex = true,
-	                                                                        bool createIfAbsent = true);
+	                                                                        bool createCollectionIfAbsent = true);
 	Future<Reference<UnboundCollectionContext>> refreshUnboundCollectionContext(Reference<UnboundCollectionContext> cx,
 	                                                                            Reference<DocTransaction> tr);
 

--- a/src/QLPlan.actor.cpp
+++ b/src/QLPlan.actor.cpp
@@ -1784,10 +1784,6 @@ ACTOR Future<int64_t> executeUntilCompletionTransactionally(Reference<Plan> plan
 	return count;
 }
 
-Future<int64_t> executeUntilCompletion(Reference<Plan> plan) {
-	return executeUntilCompletionTransactionally(plan, Reference<DocTransaction>());
-}
-
 Reference<Plan> deletePlan(Reference<Plan> subPlan, Reference<UnboundCollectionContext> cx, int64_t limit) {
 	return Reference<Plan>(
 	    new UpdatePlan(subPlan, Reference<IUpdateOp>(new DeleteDocument()), Reference<IInsertOp>(), limit, cx));

--- a/src/QLPlan.h
+++ b/src/QLPlan.h
@@ -707,13 +707,6 @@ struct FlushChangesPlan : ConcretePlan<FlushChangesPlan> {
 	                                                     Reference<DocTransaction> tr) override;
 };
 
-/**
- * Executes a plan with a new checkpoint and null transaction (so only safe to call with NonIsolatedPlan
- * or RetryPlan), throwing away all of the output and returning when it hits end of stream. Returns the
- * number of things consumed.
- */
-Future<int64_t> executeUntilCompletion(Reference<Plan> plan);
-
 // Like executeUntilCompletion(), but uses the transaction you gave it.
 Future<int64_t> executeUntilCompletionTransactionally(const Reference<Plan>& plan, const Reference<DocTransaction>& tr);
 // Like executeUntilCompletionTransactionally(), but also returns the last thing returned by the plan (if any).

--- a/src/error_definitions.h
+++ b/src/error_definitions.h
@@ -84,6 +84,7 @@ DOCLAYER_ERROR(wire_protocol_mismatch, 29966, "Wire protocol mismatch. Bad messa
 DOCLAYER_ERROR(no_index_name, 29967, "No index name specified");
 DOCLAYER_ERROR(unsupported_index_type, 29969, "Document Layer does not support this index type, yet.");
 
+DOCLAYER_ERROR(collection_not_found, 29979, "Collection not found.");
 DOCLAYER_ERROR(no_transaction_in_progress, 29980, "No transaction in progress.");
 DOCLAYER_ERROR(no_symbol_type, 29981, "The Document Layer does not support the deprecated BSON `symbol` type.");
 DOCLAYER_ERROR(compound_id_index, 29982, "You may not build a compound index including _id.");


### PR DESCRIPTION
Issue #51 points to two different problems

* We shouldn't create collections on all commands. For example, deletes and queries shouldn't create collections. Only inserts and updates should create collections.
* Transaction retries should also retry creating a collection

We are trying to address the first problem, with this PR. The second problem should be dealt with #68. Even the first one we are dealing only delete commands to fix correctness. We need to fix other issues part of a major refactoring of command handling.

