### PR TITLE
Document Layer now checks the FDB key lenth and FDB value length befo…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(fdbdoc
         QLTypes.cpp
         QLTypes.h
         StatusService.h
-        version.cpp)
+        version.cpp Constants.cpp Constants.h)
 
 set(ACTOR_FILES
         BufferedConnection.actor.cpp

--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -1,0 +1,30 @@
+/*
+ * Constants.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Constants.h"
+
+namespace DocLayerConstants {
+
+extern const uint64_t INDEX_KEY_LENGTH_LIMIT = 1024;
+
+extern const uint64_t FDB_KEY_LENGTH_LIMIT = (uint64_t)1e4;
+extern const uint64_t FDB_VALUE_LENGTH_LIMIT = (uint64_t)1e5;
+
+} // namespace DocLayerConstants

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -1,0 +1,39 @@
+/*
+ * Constants.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDB_DOC_LAYER_CONSTANTS_H
+#define FDB_DOC_LAYER_CONSTANTS_H
+
+#include <cstdint>
+
+namespace DocLayerConstants {
+// On a par with MongoDB limits
+// https://docs.mongodb.com/manual/reference/limits/#indexes
+
+extern const uint64_t INDEX_KEY_LENGTH_LIMIT;
+
+// Document Layer Limits
+
+extern const uint64_t FDB_KEY_LENGTH_LIMIT;
+extern const uint64_t FDB_VALUE_LENGTH_LIMIT;
+
+} // namespace DocLayerConstants
+
+#endif // FDB_DOC_LAYER_CONSTANTS_H

--- a/src/QLContext.actor.cpp
+++ b/src/QLContext.actor.cpp
@@ -290,18 +290,20 @@ struct IndexPlugin : ITDoc {
 
 	DataKey collectionPath;
 	DataKey indexPath;
+	std::string indexName;
 	bool error_state;
 	bool multikey;
 	bool isUniqueIndex;
 	Optional<Reference<FlowLockHolder>> flowControlLock;
 
-	IndexPlugin(DataKey collectionPath, IndexInfo indexInfo, Reference<ITDoc> next)
+	IndexPlugin(DataKey collectionPath, IndexInfo const& indexInfo, Reference<ITDoc> next)
 	    : collectionPath(collectionPath),
 	      indexPath(indexInfo.indexCx->getPrefix()), // dbName+collectionName+"metadata"+"indices"+indexName
 	      ITDoc(next),
 	      error_state(false),
 	      multikey(indexInfo.multikey),
 	      isUniqueIndex(indexInfo.isUniqueIndex),
+	      indexName(indexInfo.indexName),
 	      flowControlLock(indexInfo.isUniqueIndex ? Optional<Reference<FlowLockHolder>>(
 	                                                    Reference<FlowLockHolder>(new FlowLockHolder(new FlowLock(1))))
 	                                              : Optional<Reference<FlowLockHolder>>()) {}
@@ -417,10 +419,8 @@ struct CompoundIndexPlugin : IndexPlugin, ReferenceCounted<CompoundIndexPlugin>,
 				new_key.append(documentPath[documentPath.size() - 1]);
 				if (new_key.byteSize() > DocLayerConstants::INDEX_KEY_LENGTH_LIMIT) {
 					TraceEvent(SevError, "CompoundIndexKeyTooLarge")
-					    .detail("Offending Key size", new_key.byteSize())
-					    .detail("Index name", DataValue::decode_key_part(
-					                              DataKey::decode_item(self->indexPath[self->indexPath.size() - 1], 0))
-					                              .getString());
+					    .detail("OffendingKeySize", new_key.byteSize())
+					    .detail("IndexName", self->indexName);
 					throw index_key_too_large();
 				}
 				tr->tr->set(getFDBKey(new_key), StringRef());
@@ -447,7 +447,7 @@ struct CompoundIndexPlugin : IndexPlugin, ReferenceCounted<CompoundIndexPlugin>,
 	std::string toString() override { return "CompoundIndexPlugin"; }
 
 	CompoundIndexPlugin(DataKey collectionPath,
-	                    IndexInfo indexInfo,
+	                    IndexInfo const& indexInfo,
 	                    std::vector<std::pair<Reference<IExpression>, int>> exprs,
 	                    Reference<ITDoc> next)
 	    : IndexPlugin(collectionPath, indexInfo, next), exprs(exprs) {}
@@ -545,10 +545,8 @@ struct SimpleIndexPlugin : IndexPlugin, ReferenceCounted<SimpleIndexPlugin>, Fas
 				new_key.append(v.encode_key_part()).append(documentPath[documentPath.size() - 1]);
 				if (new_key.byteSize() > DocLayerConstants::INDEX_KEY_LENGTH_LIMIT) {
 					TraceEvent(SevError, "SimpleIndexKeyTooLarge")
-					    .detail("Offending Key size", new_key.byteSize())
-					    .detail("Index name", DataValue::decode_key_part(
-					                              DataKey::decode_item(self->indexPath[self->indexPath.size() - 1], 0))
-					                              .getString());
+					    .detail("OffendingKeySize", new_key.byteSize())
+					    .detail("IndexName", self->indexName);
 					throw index_key_too_large();
 				}
 				tr->tr->set(getFDBKey(new_key), StringRef());
@@ -566,7 +564,10 @@ struct SimpleIndexPlugin : IndexPlugin, ReferenceCounted<SimpleIndexPlugin>, Fas
 
 	std::string toString() override { return "SimpleIndexPlugin"; }
 
-	SimpleIndexPlugin(DataKey collectionPath, IndexInfo indexInfo, Reference<IExpression> expr, Reference<ITDoc> next)
+	SimpleIndexPlugin(DataKey collectionPath,
+	                  IndexInfo const& indexInfo,
+	                  Reference<IExpression> expr,
+	                  Reference<ITDoc> next)
 	    : IndexPlugin(collectionPath, indexInfo, next), expr(expr) {}
 
 	Reference<IExpression> expr;

--- a/src/error_definitions.h
+++ b/src/error_definitions.h
@@ -63,6 +63,7 @@ DOCLAYER_ERROR(replace_with_id, 16836, "The _id field cannot be changed");
 DOCLAYER_ERROR(mul_applied_to_non_number, 16837, "Cannot apply $mul to a value of non-numeric type");
 DOCLAYER_ERROR(inc_or_mul_with_non_number, 16840, "Cannot increment with non-numeric argument")
 
+DOCLAYER_ERROR(index_key_too_large, 17282, "key too large to index.");
 DOCLAYER_ERROR(bad_regex_input, 17286, "$regex operator must take string or regex object");
 DOCLAYER_ERROR(bad_sort_specifier, 17287, "Invalid sort specification passed to operation")
 DOCLAYER_ERROR(invalid_projection, 17288, "Invalid projection object passed to operation")


### PR DESCRIPTION
…re trying to write them to the backing KVS. It also now performs some checks on par with MongoDB limits, like index entry key size limit, and will fail the operation accordingly. This PR also starts putting some constant literals in one centralized place.


This is the first part to resolve issue #47