### PR TITLE
Although MongoDB only allows the index entry key's size to be upto 1K…

### DIFF
--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -22,7 +22,7 @@
 
 namespace DocLayerConstants {
 
-extern const uint64_t INDEX_KEY_LENGTH_LIMIT = 1024;
+extern const uint64_t INDEX_KEY_LENGTH_LIMIT = (uint64_t)1e4;
 
 extern const uint64_t FDB_KEY_LENGTH_LIMIT = (uint64_t)1e4;
 extern const uint64_t FDB_VALUE_LENGTH_LIMIT = (uint64_t)1e5;

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -24,13 +24,12 @@
 #include <cstdint>
 
 namespace DocLayerConstants {
+
 // On a par with MongoDB limits
 // https://docs.mongodb.com/manual/reference/limits/#indexes
-
-extern const uint64_t INDEX_KEY_LENGTH_LIMIT;
+extern const uint64_t INDEX_KEY_LENGTH_LIMIT; // This is set to 10K bytes, instead of 1K because why not.
 
 // Document Layer Limits
-
 extern const uint64_t FDB_KEY_LENGTH_LIMIT;
 extern const uint64_t FDB_VALUE_LENGTH_LIMIT;
 


### PR DESCRIPTION
…, we can loose that to 10K since KVS has no problem supporting that.