### PR TITLE
Added the 'background' flag to on-disc index metadata

### DIFF
--- a/src/ExtCmd.actor.cpp
+++ b/src/ExtCmd.actor.cpp
@@ -1279,23 +1279,28 @@ struct ListIndexesCmd {
 				}
 
 				// Add the _id index here
-				indexList << BSON("name"
-				                  << "_id_"
-				                  << "ns" << (msg->ns.first + "." + msg->ns.second) << "key" << BSON("_id" << 1)
-				                  << "metadata version" << 1 << "status"
-				                  << "ready"
-				                  << "unique" << true);
+				// clang-format off
+				indexList << BSON(
+						"name" << "_id_" <<
+						"ns" << (msg->ns.first + "." + msg->ns.second) <<
+						"key" << BSON("_id" << 1) <<
+						"metadata version" << 1 <<
+						"status" << "ready" <<
+						"unique" << true
+						);
+				// clang-format on
 
 				// FIXME: Not using cursors to return collection list.
+				// clang-format off
 				reply->addDocument(BSON(
-				    // clang-format off
-					                   "cursor" << BSON(
-						                   "id" << 0 <<
-						                        "ns" << msg->ns.first + ".$cmd.listIndexes." + msg->ns.second <<
-						                        "firstBatch" << indexList.arr()) <<
-					                            "ok" << 1.0
-				    // clang-format on
-				    ));
+						"cursor" << BSON(
+								"id" << 0 <<
+								"ns" << msg->ns.first + ".$cmd.listIndexes." + msg->ns.second <<
+								"firstBatch" << indexList.arr()) <<
+								"ok" << 1.0
+								)
+								);
+				// clang-format on
 				return reply;
 			} catch (Error& e) {
 				if (e.code() != error_code_actor_cancelled) {


### PR DESCRIPTION
Added the 'background' flag into the index on disc data, which means the old indexes do not have this information. In that case, the user may assume the field to be false. Also fixed the leaking abstraction. The fix is also future proof as in it unconditionally writes down the whole index document object when the user issued the create_index command.

I ran roughly 50K iterations of correctness tests and didn't find any new failures.