### PR TITLE
Use constant value instead of string literals.

### DIFF
--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -22,9 +22,44 @@
 
 namespace DocLayerConstants {
 
-extern const uint64_t INDEX_KEY_LENGTH_LIMIT = (uint64_t)1e4;
+const uint64_t INDEX_KEY_LENGTH_LIMIT = (uint64_t)1e4;
 
-extern const uint64_t FDB_KEY_LENGTH_LIMIT = (uint64_t)1e4;
-extern const uint64_t FDB_VALUE_LENGTH_LIMIT = (uint64_t)1e5;
+const uint64_t FDB_KEY_LENGTH_LIMIT = (uint64_t)1e4;
+const uint64_t FDB_VALUE_LENGTH_LIMIT = (uint64_t)1e5;
+
+const std::string METADATA = "metadata";
+const std::string VERSION_KEY = "version";
+const std::string INDICES_KEY = "indices";
+
+const std::string SYSTEM_INDEXES = "system.indexes";
+const std::string SYSTEM_NAMESPACES = "system.namespaces";
+
+const char* ID_FIELD = "_id";
+const char* KEY_FIELD = "key";
+const char* BUILD_ID_FIELD = "build id";
+const char* STATUS_FIELD = "status";
+const char* NAME_FIELD = "name";
+const char* UNIQUE_FIELD = "unique";
+const char* BACKGROUND_FIELD = "background";
+const char* METADATA_VERSION_FIELD = "metadata version";
+const char* NS_FIELD = "ns";
+const char* QUERY_FIELD = "query";
+const char* CURRENTLY_PROCESSING_DOC_FIELD = "currently processing document";
+
+const std::string RENAME = "$rename";
+const std::string SET = "$set";
+const std::string SET_ON_INSERT = "$setOnInsert";
+const std::string INC = "$inc";
+const std::string MUL = "$mul";
+const std::string MIN = "$min";
+const std::string MAX = "$max";
+const std::string PUSH = "$push";
+const std::string CURRENT_DATE = "$currentData";
+const std::string ADD_TO_SET = "$addToSet";
+const std::string QUERY_OPERATOR = "$query";
+
+const char* INDEX_STATUS_READY = "ready";
+const char* INDEX_STATUS_BUILDING = "building";
+const char* INDEX_STATUS_ERROR = "error";
 
 } // namespace DocLayerConstants

--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -54,7 +54,7 @@ const std::string MUL = "$mul";
 const std::string MIN = "$min";
 const std::string MAX = "$max";
 const std::string PUSH = "$push";
-const std::string CURRENT_DATE = "$currentData";
+const std::string CURRENT_DATE = "$currentDate";
 const std::string ADD_TO_SET = "$addToSet";
 const std::string QUERY_OPERATOR = "$query";
 

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -22,6 +22,7 @@
 #define FDB_DOC_LAYER_CONSTANTS_H
 
 #include <cstdint>
+#include <string>
 
 namespace DocLayerConstants {
 
@@ -32,6 +33,45 @@ extern const uint64_t INDEX_KEY_LENGTH_LIMIT; // This is set to 10K bytes, inste
 // Document Layer Limits
 extern const uint64_t FDB_KEY_LENGTH_LIMIT;
 extern const uint64_t FDB_VALUE_LENGTH_LIMIT;
+
+// KVS DocLayer internal keys
+extern const std::string METADATA;
+extern const std::string VERSION_KEY;
+extern const std::string INDICES_KEY;
+
+extern const std::string SYSTEM_INDEXES;
+extern const std::string SYSTEM_NAMESPACES;
+
+// BSON Field name constants
+extern const char* ID_FIELD;
+extern const char* KEY_FIELD;
+extern const char* BUILD_ID_FIELD;
+extern const char* STATUS_FIELD;
+extern const char* NAME_FIELD;
+extern const char* UNIQUE_FIELD;
+extern const char* BACKGROUND_FIELD;
+extern const char* METADATA_VERSION_FIELD;
+extern const char* NS_FIELD;
+extern const char* QUERY_FIELD;
+extern const char* CURRENTLY_PROCESSING_DOC_FIELD;
+
+// Mongo Operators
+extern const std::string RENAME;
+extern const std::string SET;
+extern const std::string SET_ON_INSERT;
+extern const std::string INC;
+extern const std::string MUL;
+extern const std::string MIN;
+extern const std::string MAX;
+extern const std::string PUSH;
+extern const std::string CURRENT_DATE;
+extern const std::string ADD_TO_SET;
+extern const std::string QUERY_OPERATOR;
+
+// Index status strings
+extern const char* INDEX_STATUS_READY;
+extern const char* INDEX_STATUS_BUILDING;
+extern const char* INDEX_STATUS_ERROR;
 
 } // namespace DocLayerConstants
 

--- a/src/DocLayer.actor.cpp
+++ b/src/DocLayer.actor.cpp
@@ -323,7 +323,7 @@ ACTOR Future<Void> validateStorageVersion(Reference<DocumentLayer> docLayer) {
 	int64_t timeout = 5000;
 	tr->setOption(FDB_TR_OPTION_TIMEOUT, StringRef((uint8_t*)&(timeout), sizeof(int64_t)));
 	tr->setOption(FDB_TR_OPTION_CAUSAL_READ_RISKY);
-	state FDB::Key versionKey = docLayer->rootDirectory->pack(LiteralStringRef("version"));
+	state FDB::Key versionKey = docLayer->rootDirectory->pack(StringRef(DocLayerConstants::VERSION_KEY));
 	Optional<FDB::FDBStandalone<StringRef>> version = wait(tr->get(versionKey));
 	if (version.present()) {
 		DataValue vv = DataValue::decode_value(version.get());
@@ -562,13 +562,13 @@ void printHelp(const char* name) {
 
   -l ADDRESS Listen address, specified as `[IP_ADDRESS:]PORT' (defaults
              to 127.0.0.1:27016).
-  -C CONNFILE    
+  -C CONNFILE
              The path of a file containing the connection string for the
              FoundationDB cluster. The default is first the value of the
              FDB_CLUSTER_FILE environment variable, then `./fdb.cluster',
              then `/etc/foundationdb/fdb.cluster'.
-  -d NAME    Name of the directory (managed by the Directory Layer) in the 
-             Key-Value Store which the Document Layer will use to store all 
+  -d NAME    Name of the directory (managed by the Directory Layer) in the
+             Key-Value Store which the Document Layer will use to store all
              of its state.
   -L PATH    Store log files in the given folder (default is `.').
   --loggroup LOGGROUP
@@ -580,14 +580,14 @@ void printHelp(const char* name) {
              files exceeds SIZE bytes. If set to 0, old log files will not
              be deleted. The default value is 100MiB.
   --pipeline OPTION
-             Set to `compat' to enable pipelining compatibility mode. This 
-             mode is both slower and more difficult to use correctly than 
+             Set to `compat' to enable pipelining compatibility mode. This
+             mode is both slower and more difficult to use correctly than
              the default. It should only be turned on for compatibility purposes.
   --implicit-transaction-max-retries NUMBER
-             Set the maximum number of times that transactions will be retried. 
+             Set the maximum number of times that transactions will be retried.
              Defaults to 3. If set to -1, will disable the retry limit.
   --implicit-transaction-timeout NUMBER
-             Set a timeout in milliseconds for transactions. Defaults to 7000. 
+             Set a timeout in milliseconds for transactions. Defaults to 7000.
              If set to 0, will disable all timeouts.
   --metric_plugin PATH
              The path of the metric plugin dynamic library to load during runtime.

--- a/src/DocLayer.h
+++ b/src/DocLayer.h
@@ -23,16 +23,17 @@
 
 #pragma once
 
+#include "Constants.h"
+#include "Cursor.h"
+#include "IMetric.h"
+#include "Knobs.h"
+#include "MetadataManager.h"
+
 #include "bindings/flow/DirectoryLayer.h"
 #include "bindings/flow/DirectorySubspace.h"
 #include "bindings/flow/fdb_flow.h"
 #include "flow/ActorCollection.h"
 #include "flow/flow.h"
-
-#include "Cursor.h"
-#include "IMetric.h"
-#include "Knobs.h"
-#include "MetadataManager.h"
 
 struct ConnectionOptions {
 	bool pipelineCompatMode;

--- a/src/ExtCmd.actor.cpp
+++ b/src/ExtCmd.actor.cpp
@@ -64,15 +64,15 @@ ACTOR static Future<std::pair<int, int>> dropIndexMatching(Reference<DocTransact
 			if (value.getString() == indexObj.getStringField(field.c_str())) {
 				any = true;
 				matchingIndex = indexesCollection->bindCollectionContext(tr)->cx->getSubContext(
-				    DataValue(indexObj.getField("_id")).encode_key_part());
-				matchingName = std::string(indexObj.getStringField("name"));
+				    DataValue(indexObj.getField(DocLayerConstants::ID_FIELD)).encode_key_part());
+				matchingName = std::string(indexObj.getStringField(DocLayerConstants::NAME_FIELD));
 			}
 		} else if (value.getBSONType() == bson::BSONType::Object) {
 			if (value.getPackedObject().woCompare(indexObj.getObjectField(field.c_str())) == 0) {
 				any = true;
 				matchingIndex = indexesCollection->bindCollectionContext(tr)->cx->getSubContext(
-				    DataValue(indexObj.getField("_id")).encode_key_part());
-				matchingName = std::string(indexObj.getStringField("name"));
+				    DataValue(indexObj.getField(DocLayerConstants::ID_FIELD)).encode_key_part());
+				matchingName = std::string(indexObj.getStringField(DocLayerConstants::NAME_FIELD));
 			}
 		}
 	}
@@ -120,7 +120,11 @@ ACTOR static Future<Reference<ExtMsgReply>> doDropDatabase(Reference<ExtConnecti
 		reply->addDocument(BSON("ok" << 1.0));
 		return reply;
 	} catch (Error& e) {
-		reply->addDocument(BSON("ok" << 1.0 << "err" << e.what() << "code" << e.code()));
+		// clang-format off
+		reply->addDocument(BSON("ok" << 1.0 <<
+		                        "err" << e.what() <<
+		                        "code" << e.code()));
+		// clang-format on
 		return reply;
 	}
 }
@@ -140,8 +144,10 @@ struct WhatsmyuriCmd {
 	static Future<Reference<ExtMsgReply>> call(Reference<ExtConnection> nmc,
 	                                           Reference<ExtMsgQuery> query,
 	                                           Reference<ExtMsgReply> reply) {
-		reply->addDocument(BSON("you" << nmc->bc->getPeerAddress().toString() << "ok" << 1.0));
-
+		// clang-format off
+		reply->addDocument(BSON("you" << nmc->bc->getPeerAddress().toString() <<
+		                        "ok" << 1.0));
+		// clang-format on
 		return Future<Reference<ExtMsgReply>>(reply);
 	}
 };
@@ -152,7 +158,10 @@ struct GetCmdLineOptsCmd {
 	static Future<Reference<ExtMsgReply>> call(Reference<ExtConnection> nmc,
 	                                           Reference<ExtMsgQuery> query,
 	                                           Reference<ExtMsgReply> reply) {
-		reply->addDocument(BSON("argv" << BSON_ARRAY("fdbdoc") << "ok" << 1.0));
+		// clang-format off
+		reply->addDocument(BSON("argv" << BSON_ARRAY("fdbdoc") <<
+		                        "ok" << 1.0));
+		// clang-format on
 
 		return Future<Reference<ExtMsgReply>>(reply);
 	}
@@ -217,9 +226,10 @@ struct GetLogCmd {
 		bson::BSONObjBuilder bob;
 
 		if (query->ns.first != "admin") {
-			reply->addDocument((bob << "ok" << 0.0 << "errmsg"
-			                        << "access denied; use admin db")
-			                       .obj());
+			// clang-format off
+			reply->addDocument((bob << "ok" << 0.0 <<
+			                           "errmsg" << "access denied; use admin db").obj());
+			// clang-format on
 			return reply;
 		}
 
@@ -400,7 +410,7 @@ ACTOR static Future<Reference<ExtMsgReply>> getStreamCount(Reference<ExtConnecti
 	try {
 		state Reference<DocTransaction> dtr = ec->getOperationTransaction();
 		Reference<UnboundCollectionContext> cx = wait(ec->mm->getUnboundCollectionContext(dtr, query->ns, true));
-		Reference<Plan> plan = planQuery(cx, query->query.getObjectField("query"));
+		Reference<Plan> plan = planQuery(cx, query->query.getObjectField(DocLayerConstants::QUERY_FIELD));
 		plan = ec->wrapOperationPlan(plan, true, cx);
 
 		// fprintf(stderr, "Plan: %s\n", plan->describe().toString().c_str());
@@ -442,8 +452,9 @@ ACTOR static Future<Reference<ExtMsgReply>> doFindAndModify(Reference<ExtConnect
 		state bool isupdate = query->query.hasField("update");
 		state bool isupsert =
 		    isupdate && query->query.hasField("upsert") && query->query.getField("upsert").trueValue();
-		state bson::BSONObj selector =
-		    query->query.hasField("query") ? query->query.getObjectField("query").getOwned() : bson::BSONObj();
+		state bson::BSONObj selector = query->query.hasField(DocLayerConstants::QUERY_FIELD)
+		                                   ? query->query.getObjectField(DocLayerConstants::QUERY_FIELD).getOwned()
+		                                   : bson::BSONObj();
 		state Reference<Projection> projection = query->query.hasField("fields")
 		                                             ? parseProjection(query->query.getObjectField("fields").getOwned())
 		                                             : Reference<Projection>(new Projection());
@@ -524,7 +535,7 @@ ACTOR static Future<Reference<ExtMsgReply>> doFindAndModify(Reference<ExtConnect
 		lastErrorObject.appendBool("updatedExisting", i && !returnedUpserted);
 		lastErrorObject.appendNumber("n", (int)i);
 		if (returnedUpserted)
-			lastErrorObject.append(retval.getField("_id"));
+			lastErrorObject.append(retval.getField(DocLayerConstants::ID_FIELD));
 		bson::BSONObj lastErrorObj = lastErrorObject.obj().getOwned();
 		bob.appendObject("lastErrorObject", lastErrorObj.objdata());
 		bob.appendNumber("ok", 1.0);
@@ -581,14 +592,15 @@ ACTOR static Future<Reference<ExtMsgReply>> doDropIndexesActor(Reference<ExtConn
 					return reply;
 				} else {
 					if (ec->explicitTransaction) {
-						std::pair<int, int> result = wait(dropIndexMatching(
-						    ec->tr, query->ns, "name", DataValue(el.String(), DVTypeCode::STRING), ec->mm));
+						std::pair<int, int> result =
+						    wait(dropIndexMatching(ec->tr, query->ns, DocLayerConstants::NAME_FIELD,
+						                           DataValue(el.String(), DVTypeCode::STRING), ec->mm));
 						dropped = result.first;
 					} else {
 						std::pair<int, int> result = wait(runRYWTransaction(
 						    ec->docLayer->database,
-						    [=](Reference<DocTransaction> tr) {
-							    return dropIndexMatching(tr, query->ns, "name",
+						    [this, el](Reference<DocTransaction> tr) {
+							    return dropIndexMatching(tr, query->ns, DocLayerConstants::NAME_FIELD,
 							                             DataValue(el.String(), DVTypeCode::STRING), ec->mm);
 						    },
 						    ec->options.retryLimit, ec->options.timeoutMillies));
@@ -600,15 +612,15 @@ ACTOR static Future<Reference<ExtMsgReply>> doDropIndexesActor(Reference<ExtConn
 				}
 			} else if (el.type() == bson::BSONType::Object) {
 				if (ec->explicitTransaction) {
-					std::pair<int, int> result =
-					    wait(dropIndexMatching(ec->tr, query->ns, "key", DataValue(el.Obj()), ec->mm));
+					std::pair<int, int> result = wait(dropIndexMatching(ec->tr, query->ns, DocLayerConstants::KEY_FIELD,
+					                                                    DataValue(el.Obj()), ec->mm));
 					dropped = result.first;
 				} else {
 					std::pair<int, int> result =
 					    wait(runRYWTransaction(ec->docLayer->database,
-					                           [=](Reference<DocTransaction> tr) {
-						                           return dropIndexMatching(tr, query->ns, "key", DataValue(el.Obj()),
-						                                                    ec->mm);
+					                           [this, el](Reference<DocTransaction> tr) {
+						                           return dropIndexMatching(tr, query->ns, DocLayerConstants::KEY_FIELD,
+						                                                    DataValue(el.Obj()), ec->mm);
 					                           },
 					                           ec->options.retryLimit, ec->options.timeoutMillies));
 					dropped = result.first;
@@ -632,13 +644,19 @@ ACTOR static Future<Reference<ExtMsgReply>> doDropIndexesActor(Reference<ExtConn
 				dropped = result;
 			}
 
-			reply->addDocument(BSON("nIndexesWas" << dropped + 1 << "msg"
-			                                      << "non-_id indexes dropped for collection"
-			                                      << "ok" << 1.0));
+			// clang-format off
+			reply->addDocument(BSON("nIndexesWas" << dropped + 1 <<
+			                        "msg" << "non-_id indexes dropped for collection" <<
+			                        "ok" << 1.0));
+			// clang-format on
 			return reply;
 		}
 	} catch (Error& e) {
-		reply->addDocument(BSON("ok" << 0.0 << "err" << e.what() << "code" << e.code()));
+		// clang-format off
+		reply->addDocument(BSON("ok" << 0.0 <<
+		                        "err" << e.what() <<
+		                        "code" << e.code()));
+		// clang-format on
 		return reply;
 	}
 }
@@ -731,7 +749,8 @@ ACTOR static Future<Reference<ExtMsgReply>> listDatabases(Reference<DocTransacti
 		dbName = db.toString();
 		Standalone<VectorRef<StringRef>> colls = wait(rootDirectory->list(tr->tr, {db}));
 		bool empty = colls.empty();
-		bab.append(BSON("name" << dbName << "sizeOnDisk" << (empty ? 0 : 1000000) << "empty" << empty));
+		bab.append(
+		    BSON(DocLayerConstants::NAME_FIELD << dbName << "sizeOnDisk" << (empty ? 0 : 1000000) << "empty" << empty));
 	}
 
 	bob.appendArray("databases", bab.arr());
@@ -783,8 +802,8 @@ ACTOR static Future<Reference<ExtMsgReply>> getCollectionStats(Reference<ExtConn
 	state Reference<DocTransaction> tr = ec->getOperationTransaction();
 	state Reference<Plan> plan = wait(getIndexesForCollectionPlan(query->ns, tr, ec->mm));
 	state int64_t indexesCount = wait(executeUntilCompletionTransactionally(plan, tr));
-	reply->addDocument(
-	    BSON("ns" << query->ns.first + "." + query->ns.second << "nindexes" << (int)indexesCount + 1 << "ok" << 1.0));
+	reply->addDocument(BSON(DocLayerConstants::NS_FIELD << query->ns.first + "." + query->ns.second << "nindexes"
+	                                                    << (int)indexesCount + 1 << "ok" << 1.0));
 	return reply;
 }
 
@@ -1176,7 +1195,7 @@ ACTOR static Future<Reference<ExtMsgReply>> updateAndReply(Reference<ExtConnecti
 			auto& upsertedOID = ret.upsertedOIDList[i];
 			bson::BSONObjBuilder builder;
 			builder << "index" << i;
-			builder.appendElements(DataValue::decode_key_part(upsertedOID).wrap("_id"));
+			builder.appendElements(DataValue::decode_key_part(upsertedOID).wrap(DocLayerConstants::ID_FIELD));
 			upsertBuilder << builder.done();
 		}
 		replyBuilder << "upserted" << upsertBuilder.arr();
@@ -1231,7 +1250,8 @@ struct ListCollectionsCmd {
 
 		bson::BSONArrayBuilder collList;
 		for (Standalone<StringRef> name : names) {
-			collList << BSON("name" << name.toString() << "options" << bson::BSONObjBuilder().obj());
+			collList << BSON(DocLayerConstants::NAME_FIELD << name.toString() << "options"
+			                                               << bson::BSONObjBuilder().obj());
 		}
 
 		// FIXME: Not using cursors to return collection list.
@@ -1239,7 +1259,7 @@ struct ListCollectionsCmd {
 		    // clang-format off
 							   "cursor" << BSON(
 								   "id" << (long long) 0 <<
-								   "ns" << databaseName + ".$cmd.listCollections" <<
+								   DocLayerConstants::NS_FIELD << databaseName + ".$cmd.listCollections" <<
 								   "firstBatch" << collList.arr()) <<
 								   "ok" << 1.0
 		    // clang-format on
@@ -1281,12 +1301,12 @@ struct ListIndexesCmd {
 				// Add the _id index here
 				// clang-format off
 				indexList << BSON(
-						"name" << "_id_" <<
-						"ns" << (msg->ns.first + "." + msg->ns.second) <<
-						"key" << BSON("_id" << 1) <<
-						"metadata version" << 1 <<
-						"status" << "ready" <<
-						"unique" << true
+						DocLayerConstants::NAME_FIELD             << "_id_" <<
+						DocLayerConstants::NS_FIELD               << (msg->ns.first + "." + msg->ns.second) <<
+						DocLayerConstants::KEY_FIELD              << BSON(DocLayerConstants::ID_FIELD << 1) <<
+						DocLayerConstants::METADATA_VERSION_FIELD << 1 <<
+						DocLayerConstants::STATUS_FIELD           << DocLayerConstants::INDEX_STATUS_READY <<
+						DocLayerConstants::UNIQUE_FIELD           << true
 						);
 				// clang-format on
 
@@ -1294,10 +1314,10 @@ struct ListIndexesCmd {
 				// clang-format off
 				reply->addDocument(BSON(
 						"cursor" << BSON(
-								"id" << 0 <<
-								"ns" << msg->ns.first + ".$cmd.listIndexes." + msg->ns.second <<
-								"firstBatch" << indexList.arr()) <<
-								"ok" << 1.0
+								"id"           << 0 <<
+								"ns"           << msg->ns.first + ".$cmd.listIndexes." + msg->ns.second <<
+								"firstBatch"   << indexList.arr()) <<
+								"ok"           << 1.0
 								)
 								);
 				// clang-format on
@@ -1323,12 +1343,12 @@ ACTOR static Future<Reference<ExtMsgReply>> getStreamDistinct(Reference<ExtConne
 		state Reference<DocTransaction> dtr = ec->getOperationTransaction();
 		Reference<UnboundCollectionContext> cx = wait(ec->mm->getUnboundCollectionContext(dtr, query->ns, true));
 
-		if (!query->query.hasField("key")) {
+		if (!query->query.hasField(DocLayerConstants::KEY_FIELD)) {
 			throw wire_protocol_mismatch();
 		}
-		state std::string keyValue = query->query.getStringField("key");
+		state std::string keyValue = query->query.getStringField(DocLayerConstants::KEY_FIELD);
 
-		Reference<Plan> qrPlan = planQuery(cx, query->query.getObjectField("query"));
+		Reference<Plan> qrPlan = planQuery(cx, query->query.getObjectField(DocLayerConstants::QUERY_FIELD));
 		qrPlan = ec->wrapOperationPlan(qrPlan, true, cx);
 		state Reference<DistinctPredicate> distinctPredicate = ref(new DistinctPredicate(keyValue));
 		state Reference<IPredicate> predicate = any_predicate(keyValue, distinctPredicate);
@@ -1361,13 +1381,17 @@ ACTOR static Future<Reference<ExtMsgReply>> getStreamDistinct(Reference<ExtConne
 		// `nscanned`: Number of documents or indexes scanned
 		// `nscannedObjects`: Number of documents scanned
 		// `nscanned` and `nscannedObjects` should always be the same here.
+		// clang-format off
 		reply->addDocument(
 		    BSON("values" << arrayBuilder.arr() << "stats"
-		                  << BSON("n" << filtered << "nscanned" << scanned << "nscannedObjects" << scanned << "timems"
-		                              << int((timer_monotonic() - startTime) * 1e3) << "cursor"
-		                              << "BasicCursor")
+		                  << BSON("n" << filtered <<
+		                          "nscanned" << scanned <<
+		                          "nscannedObjects" << scanned <<
+		                          "timems" << int((timer_monotonic() - startTime) * 1e3) <<
+		                          "cursor" << "BasicCursor"
+		                          )
 		                  << "ok" << 1.0));
-
+		// clang-format on
 		return reply;
 	} catch (Error& e) {
 		reply->addDocument(BSON("$err" << e.what() << "code" << e.code() << "ok" << 1.0));

--- a/src/ExtCmd.actor.cpp
+++ b/src/ExtCmd.actor.cpp
@@ -599,7 +599,7 @@ ACTOR static Future<Reference<ExtMsgReply>> doDropIndexesActor(Reference<ExtConn
 					} else {
 						std::pair<int, int> result = wait(runRYWTransaction(
 						    ec->docLayer->database,
-						    [this, el](Reference<DocTransaction> tr) {
+						    [=](Reference<DocTransaction> tr) {
 							    return dropIndexMatching(tr, query->ns, DocLayerConstants::NAME_FIELD,
 							                             DataValue(el.String(), DVTypeCode::STRING), ec->mm);
 						    },
@@ -618,7 +618,7 @@ ACTOR static Future<Reference<ExtMsgReply>> doDropIndexesActor(Reference<ExtConn
 				} else {
 					std::pair<int, int> result =
 					    wait(runRYWTransaction(ec->docLayer->database,
-					                           [this, el](Reference<DocTransaction> tr) {
+					                           [=](Reference<DocTransaction> tr) {
 						                           return dropIndexMatching(tr, query->ns, DocLayerConstants::KEY_FIELD,
 						                                                    DataValue(el.Obj()), ec->mm);
 					                           },

--- a/src/ExtCmd.h
+++ b/src/ExtCmd.h
@@ -27,6 +27,7 @@
 
 #include "flow/flow.h"
 
+#include "Constants.h"
 #include "ExtMsg.h"
 #include "ExtStructs.h"
 #include "IDispatched.h"

--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -791,7 +791,7 @@ ACTOR Future<WriteCmdResult> attemptIndexInsertion(bson::BSONObj indexObj,
 		}
 	}
 
-	state bool background = indexObj.hasField(DocLayerConstants::BACKGROUND_FIELD);
+	state bool background = indexObj.getBoolField(DocLayerConstants::BACKGROUND_FIELD);
 	if (indexObj.getBoolField(DocLayerConstants::UNIQUE_FIELD) && background) {
 		throw unique_index_background_construction();
 	}

--- a/src/ExtMsg.h
+++ b/src/ExtMsg.h
@@ -23,19 +23,18 @@
 
 #pragma once
 
-#include "flow/flow.h"
-
-#include "bson.h"
-
-#include "IDispatched.h"
-
+#include "Constants.h"
 #include "Ext.h"
 #include "ExtOperator.h"
 #include "ExtStructs.h"
 #include "ExtUtil.actor.h"
-
+#include "IDispatched.h"
 #include "QLPlan.h"
 #include "QLPredicate.h"
+
+#include "flow/flow.h"
+
+#include "bson.h"
 
 struct ExtMsg : IDispatched<ExtMsg, int32_t, std::function<ExtMsg*(ExtMsgHeader*, const uint8_t*)>>,
                 ReferenceCounted<ExtMsg> {
@@ -216,9 +215,6 @@ private:
 	ExtMsgKillCursors(ExtMsgHeader*, const uint8_t*);
 	friend struct ExtMsg::Factory<ExtMsgKillCursors>;
 };
-
-static const char* namespaces = "system.namespaces";
-static const char* indexes_collection = "system.indexes";
 
 Reference<Plan> planQuery(Reference<UnboundCollectionContext> cx, const bson::BSONObj& query);
 std::vector<std::string> staticValidateUpdateObject(bson::BSONObj update, bool multi, bool upsert);

--- a/src/ExtUtil.actor.cpp
+++ b/src/ExtUtil.actor.cpp
@@ -771,7 +771,8 @@ Future<Reference<Plan>> getIndexesForCollectionPlan(Namespace const& ns,
 	std::string nsStr = ns.first + "." + ns.second;
 	Future<Reference<UnboundCollectionContext>> unbound = mm->indexesCollection(tr, ns.first);
 	return map(unbound, [nsStr](Reference<UnboundCollectionContext> unbound) {
-		Reference<IPredicate> pred = any_predicate("ns", ref(new EqPredicate(DataValue(nsStr))), false);
+		Reference<IPredicate> pred =
+		    any_predicate(DocLayerConstants::NS_FIELD, ref(new EqPredicate(DataValue(nsStr))), false);
 		return FilterPlan::construct_filter_plan_no_pushdown(unbound, ref(new TableScanPlan(unbound)), pred);
 	});
 }
@@ -779,7 +780,8 @@ Future<Reference<Plan>> getIndexesForCollectionPlan(Namespace const& ns,
 Reference<Plan> getIndexesForCollectionPlan(Reference<UnboundCollectionContext> indexesCollection,
                                             Namespace const& ns) {
 	std::string nsStr = ns.first + "." + ns.second;
-	Reference<IPredicate> pred = any_predicate("ns", ref(new EqPredicate(DataValue(nsStr))), false);
+	Reference<IPredicate> pred =
+	    any_predicate(DocLayerConstants::NS_FIELD, ref(new EqPredicate(DataValue(nsStr))), false);
 	return FilterPlan::construct_filter_plan_no_pushdown(indexesCollection, ref(new TableScanPlan(indexesCollection)),
 	                                                     pred);
 }
@@ -831,7 +833,7 @@ Reference<Projection> parseProjection(bson::BSONObj const& fieldSelector) {
 			throw invalid_projection();
 		} else {
 			bool elIncluded = el.trueValue();
-			if (fieldName == "_id") {
+			if (fieldName == DocLayerConstants::ID_FIELD) {
 				// Specifying _id:1 makes the projection an inclusive projection
 				if (elIncluded) {
 					if (hasIncludeValue && root->included) {
@@ -893,7 +895,7 @@ Reference<Projection> parseProjection(bson::BSONObj const& fieldSelector) {
 	}
 
 	if (includeID != root->included) {
-		root->fields["_id"] = Reference<Projection>(new Projection(includeID));
+		root->fields[DocLayerConstants::ID_FIELD] = Reference<Projection>(new Projection(includeID));
 	}
 
 	Projection::filterUnneededReads(root);

--- a/src/MetadataManager.h
+++ b/src/MetadataManager.h
@@ -23,8 +23,10 @@
 
 #pragma once
 
+#include "Constants.h"
 #include "QLContext.h"
 #include "QLTypes.h"
+
 #include "bindings/flow/DirectorySubspace.h"
 
 using Namespace = std::pair<std::string, std::string>;
@@ -43,7 +45,8 @@ struct MetadataManager : ReferenceCounted<MetadataManager>, NonCopyable {
 
 	Future<Reference<UnboundCollectionContext>> indexesCollection(Reference<DocTransaction> tr,
 	                                                              std::string const& dbName) {
-		return getUnboundCollectionContext(tr, std::make_pair(dbName, std::string("system.indexes")), true);
+		return getUnboundCollectionContext(tr, std::make_pair(dbName, std::string(DocLayerConstants::SYSTEM_INDEXES)),
+		                                   true);
 	}
 
 	static Future<Void> buildIndex(bson::BSONObj indexObj,

--- a/src/QLContext.actor.cpp
+++ b/src/QLContext.actor.cpp
@@ -705,7 +705,7 @@ void UnboundCollectionContext::addIndex(IndexInfo info) {
 
 Key UnboundCollectionContext::getIndexesSubspace() {
 	return Standalone<StringRef>(metadataDirectory->key().toString() +
-	                             DataValue(std::string("indices")).encode_key_part());
+	                             DataValue(std::string(DocLayerConstants::INDICES_KEY)).encode_key_part());
 }
 
 Reference<UnboundQueryContext> UnboundCollectionContext::getIndexesContext() {
@@ -740,8 +740,8 @@ Optional<IndexInfo> UnboundCollectionContext::getCompoundIndex(std::vector<std::
 }
 
 Key UnboundCollectionContext::getVersionKey() {
-	return Key(
-	    KeyRef(metadataDirectory->key().toString() + DataValue("version", DVTypeCode::STRING).encode_key_part()));
+	return Key(KeyRef(metadataDirectory->key().toString() +
+	                  DataValue(DocLayerConstants::VERSION_KEY, DVTypeCode::STRING).encode_key_part()));
 }
 
 std::string UnboundCollectionContext::databaseName() {
@@ -770,14 +770,16 @@ Future<uint64_t> CollectionContext::getMetadataVersion() {
 }
 
 Future<Standalone<StringRef>> IReadWriteContext::getValueEncodedId() {
-	return map(getMaybeRecursiveIfPresent(getSubContext(DataValue("_id", DVTypeCode::STRING).encode_key_part())),
+	return map(getMaybeRecursiveIfPresent(
+	               getSubContext(DataValue(DocLayerConstants::ID_FIELD, DVTypeCode::STRING).encode_key_part())),
 	           [](Optional<DataValue> odv) -> Standalone<StringRef> {
 		           return odv.present() ? odv.get().encode_value() : StringRef();
 	           }); // FIXME: this is inefficient in about 12 different ways
 }
 
 Future<Standalone<StringRef>> IReadWriteContext::getKeyEncodedId() {
-	return map(getMaybeRecursiveIfPresent(getSubContext(DataValue("_id", DVTypeCode::STRING).encode_key_part())),
+	return map(getMaybeRecursiveIfPresent(
+	               getSubContext(DataValue(DocLayerConstants::ID_FIELD, DVTypeCode::STRING).encode_key_part())),
 	           [](Optional<DataValue> odv) -> Standalone<StringRef> {
 		           return odv.present() ? odv.get().encode_key_part() : StringRef();
 	           }); // FIXME: this is inefficient in about 12 different ways

--- a/src/QLContext.h
+++ b/src/QLContext.h
@@ -22,11 +22,14 @@
 #define _QL_CONTEXT_H
 #pragma once
 
+#include "Constants.h"
 #include "Knobs.h"
 #include "QLTypes.h"
+
 #include "bindings/flow/DirectorySubspace.h"
 #include "bindings/flow/fdb_flow.h"
 #include "flow/flow.h"
+
 using namespace FDB;
 
 struct FlowLockHolder : ReferenceCounted<FlowLockHolder> {


### PR DESCRIPTION
 This PR changed some places where it directly uses string literals to use constants values defined in the constants namespace.