### PR TITLE
Resolves #99: Clean internal state of DocTransaction on tr->onError()

### DIFF
--- a/src/ExtCmd.actor.cpp
+++ b/src/ExtCmd.actor.cpp
@@ -1224,7 +1224,7 @@ struct ListCollectionsCmd {
 					break;
 				}
 				if (e.code() != error_code_actor_cancelled) {
-					Void _ = wait(dtr->tr->onError(e));
+					Void _ = wait(dtr->onError(e));
 				}
 			}
 		}
@@ -1304,7 +1304,7 @@ struct ListIndexesCmd {
 				return reply;
 			} catch (Error& e) {
 				if (e.code() != error_code_actor_cancelled) {
-					Void _ = wait(dtr->tr->onError(e));
+					Void _ = wait(dtr->onError(e));
 				}
 			}
 		}

--- a/src/QLContext.h
+++ b/src/QLContext.h
@@ -85,6 +85,8 @@ struct DocTransaction : ReferenceCounted<DocTransaction> {
 	}
 	static Future<Void> commitChanges(Reference<DocTransaction> const& self, std::string const& docPrefix);
 
+	Future<Void> onError(Error const& e);
+
 	// If you are about to call this function, think very carefully about why you are doing that. It is not safe to call
 	// in general. Look at the comments in doNonIsolatedRW() for more on what it's for.
 	void cancel_ongoing_index_reads();

--- a/src/QLPlan.actor.cpp
+++ b/src/QLPlan.actor.cpp
@@ -857,7 +857,7 @@ ACTOR static Future<Void> doNonIsolatedRW(PlanCheckpoint* outerCheckpoint,
 					bufferedDocs.pop_front();
 				}
 			} catch (Error& e) {
-				Void _ = wait(dtr->tr->onError(e));
+				Void _ = wait(dtr->onError(e));
 				finished = false;
 			}
 
@@ -957,7 +957,7 @@ ACTOR static Future<Void> doRetry(Reference<Plan> subPlan,
 					throw;
 				if (e.code() == error_code_end_of_stream)
 					throw;
-				Void _ = wait(tr->tr->onError(e));
+				Void _ = wait(tr->onError(e));
 				tr = self->newTransaction(); // FIXME: keep dtr->tr if this is a retry
 			}
 		}


### PR DESCRIPTION
By not cleaning DocTransaction state which internally depends on FDB
transaction state, concurrent actors during onError() are causing
segfault.