### PR TITLE
Use the idiomatic RAII lock releaser.

### DIFF
--- a/src/QLContext.actor.cpp
+++ b/src/QLContext.actor.cpp
@@ -306,7 +306,7 @@ struct IndexPlugin : ITDoc {
 	bool error_state;
 	bool multikey;
 	bool isUniqueIndex;
-	Optional<Reference<FlowLockHolder>> flowControlLock;
+	Optional<Reference<FlowLock>> flowControlLock;
 
 	IndexPlugin(DataKey collectionPath, IndexInfo const& indexInfo, Reference<ITDoc> next)
 	    : collectionPath(collectionPath),
@@ -316,9 +316,8 @@ struct IndexPlugin : ITDoc {
 	      multikey(indexInfo.multikey),
 	      isUniqueIndex(indexInfo.isUniqueIndex),
 	      indexName(indexInfo.indexName),
-	      flowControlLock(indexInfo.isUniqueIndex ? Optional<Reference<FlowLockHolder>>(
-	                                                    Reference<FlowLockHolder>(new FlowLockHolder(new FlowLock(1))))
-	                                              : Optional<Reference<FlowLockHolder>>()) {}
+	      flowControlLock(indexInfo.isUniqueIndex ? Optional<Reference<FlowLock>>(new FlowLock(1))
+	                                              : Optional<Reference<FlowLock>>()) {}
 };
 
 struct CompoundIndexPlugin : IndexPlugin, ReferenceCounted<CompoundIndexPlugin>, FastAllocated<CompoundIndexPlugin> {
@@ -376,12 +375,13 @@ struct CompoundIndexPlugin : IndexPlugin, ReferenceCounted<CompoundIndexPlugin>,
 				// for all new entries going to be written, before we clear the potentially existing old index entries,
 				// we need to make sure there is no existing unique index for that new value under path
 				// dbName+collectionName+"metadata"+"indices"+encodedIndexName+encodedValue
-				if (self->flowControlLock.present()) {
-					// When building the unique index, each record out of the table scan needs to wait for the previous
-					// one finished duplication detecting and index record writing. And thus the following section
-					// before the `lock.release()` call, needs to be protected using a mutex lock.
-					Void _ = wait(self->flowControlLock.get()->lock->take(1));
-				}
+
+				// When building the unique index, each record out of the table scan needs to wait for the previous
+				// one finished duplication detecting and index record writing. And thus the following section
+				// before the `lock.release()` call, needs to be protected using a mutex lock.
+				state FlowLock::Releaser releaser(*self->flowControlLock.get(), 1);
+				Void _ = wait(self->flowControlLock.get()->take(1));
+
 				for (; nvv; ++nvv) {
 					DataKey potential_index_key(self->indexPath);
 					for (int i = 0; i < nvv.size(); i++)
@@ -436,10 +436,6 @@ struct CompoundIndexPlugin : IndexPlugin, ReferenceCounted<CompoundIndexPlugin>,
 					throw index_key_too_large();
 				}
 				tr->tr->set(getFDBKey(new_key), StringRef());
-			}
-
-			if (self->flowControlLock.present()) {
-				self->flowControlLock.get()->lock->release(1);
 			}
 
 		} catch (Error& e) {
@@ -507,12 +503,12 @@ struct SimpleIndexPlugin : IndexPlugin, ReferenceCounted<SimpleIndexPlugin>, Fas
 				// we need to make sure there is no existing unique index for that new value under path
 				// dbName+collectionName+"metadata"+"indices"+encodedIndexName+encodedValue
 
-				if (self->flowControlLock.present()) {
-					// When building the unique index, each record out of the table scan needs to wait for the previous
-					// one finished duplication detecting and index record writing. And thus the following section
-					// before the `lock.release()` call, needs to be protected using a mutex lock.
-					Void _ = wait(self->flowControlLock.get()->lock->take(1));
-				}
+				// When building the unique index, each record out of the table scan needs to wait for the previous
+				// one finished duplication detecting and index record writing. And thus the following section
+				// before the `lock.release()` call, needs to be protected using a mutex lock.
+				state FlowLock::Releaser releaser(*self->flowControlLock.get(), 1);
+				Void _ = wait(self->flowControlLock.get()->take(1));
+
 				for (const DataValue& v : new_values) {
 					state DataKey potential_index_key(self->indexPath);
 					potential_index_key.append(v.encode_key_part());
@@ -562,9 +558,6 @@ struct SimpleIndexPlugin : IndexPlugin, ReferenceCounted<SimpleIndexPlugin>, Fas
 					throw index_key_too_large();
 				}
 				tr->tr->set(getFDBKey(new_key), StringRef());
-			}
-			if (self->flowControlLock.present()) {
-				self->flowControlLock.get()->lock->release(1);
 			}
 		} catch (Error& e) {
 			TraceEvent(SevError, "BD_doIndexUpdate").detail("error", e.what());

--- a/src/QLContext.actor.cpp
+++ b/src/QLContext.actor.cpp
@@ -380,8 +380,8 @@ struct CompoundIndexPlugin : IndexPlugin, ReferenceCounted<CompoundIndexPlugin>,
 				// one finished duplication detecting and index record writing. And thus the following section
 				// before the `lock.release()` call, needs to be protected using a mutex lock.
 				ASSERT(self->flowControlLock.present());
-				state FlowLock::Releaser releaser(*self->flowControlLock.get(), 1);
 				Void _ = wait(self->flowControlLock.get()->take(1));
+				state FlowLock::Releaser releaser(*self->flowControlLock.get(), 1);
 
 				for (; nvv; ++nvv) {
 					DataKey potential_index_key(self->indexPath);
@@ -508,8 +508,8 @@ struct SimpleIndexPlugin : IndexPlugin, ReferenceCounted<SimpleIndexPlugin>, Fas
 				// one finished duplication detecting and index record writing. And thus the following section
 				// before the `lock.release()` call, needs to be protected using a mutex lock.
 				ASSERT(self->flowControlLock.present());
-				state FlowLock::Releaser releaser(*self->flowControlLock.get(), 1);
 				Void _ = wait(self->flowControlLock.get()->take(1));
+				state FlowLock::Releaser releaser(*self->flowControlLock.get(), 1);
 
 				for (const DataValue& v : new_values) {
 					state DataKey potential_index_key(self->indexPath);

--- a/src/QLContext.actor.cpp
+++ b/src/QLContext.actor.cpp
@@ -379,6 +379,7 @@ struct CompoundIndexPlugin : IndexPlugin, ReferenceCounted<CompoundIndexPlugin>,
 				// When building the unique index, each record out of the table scan needs to wait for the previous
 				// one finished duplication detecting and index record writing. And thus the following section
 				// before the `lock.release()` call, needs to be protected using a mutex lock.
+				ASSERT(self->flowControlLock.present());
 				state FlowLock::Releaser releaser(*self->flowControlLock.get(), 1);
 				Void _ = wait(self->flowControlLock.get()->take(1));
 
@@ -506,6 +507,7 @@ struct SimpleIndexPlugin : IndexPlugin, ReferenceCounted<SimpleIndexPlugin>, Fas
 				// When building the unique index, each record out of the table scan needs to wait for the previous
 				// one finished duplication detecting and index record writing. And thus the following section
 				// before the `lock.release()` call, needs to be protected using a mutex lock.
+				ASSERT(self->flowControlLock.present());
 				state FlowLock::Releaser releaser(*self->flowControlLock.get(), 1);
 				Void _ = wait(self->flowControlLock.get()->take(1));
 


### PR DESCRIPTION
Now instead of manually releasing the lock and adding try-catch blocks across the code, simply use the idiomatic RAII style lock releaser whose dtor is guaranteed to be called once the ACTOR gets out of scope, i.e. died

This resolves #106 