### PR TITLE
Ignore index_wrong_build_id error in correctness.

### DIFF
--- a/src/QLPlan.h
+++ b/src/QLPlan.h
@@ -669,13 +669,13 @@ struct UpdateIndexStatusPlan : ConcretePlan<UpdateIndexStatusPlan> {
 	Standalone<StringRef> encodedIndexId;
 	Reference<MetadataManager> mm;
 	std::string newStatus;
-	Optional<UID> buildId;
+	UID buildId;
 
 	UpdateIndexStatusPlan(Namespace const& ns,
 	                      Standalone<StringRef> encodedIndexId,
 	                      Reference<MetadataManager> mm,
 	                      std::string newStatus,
-	                      Optional<UID> buildId = Optional<UID>())
+	                      UID buildId)
 	    : ns(ns), encodedIndexId(encodedIndexId), mm(mm), newStatus(newStatus), buildId(buildId) {}
 
 	bson::BSONObj describe() override {

--- a/test/correctness/document-correctness.py
+++ b/test/correctness/document-correctness.py
@@ -424,9 +424,12 @@ def one_iteration(collection1, collection2, ns, seed):
 
 ignored_exceptions = [
     "Multi-multikey index size exceeds maximum value",
-    "key too large to index", # it's hard to estimate the exact byte size of KVS key to be inserted, ignore for now.
+    "key too large to index",  # it's hard to estimate the exact byte size of KVS key to be inserted, ignore for now.
     "Key length exceeds limit",
     "Operation aborted because the transaction timed out",
+    # This is another variant of "Operation aborted" error. For now, ignoring this error. We have to fix this part of
+    # transaction handling redesign.
+    "Attempting to change status of a different index build",
 ]
 
 


### PR DESCRIPTION
Also

* UpdateIndexPlan should always get a valid `buildId`
* Adding few more `TraceEvent` on error messages.

Resolves issue #52.