### PR TITLE
Make UnboundCollectionContext versioned.

### DIFF
--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -28,6 +28,7 @@ const uint64_t FDB_KEY_LENGTH_LIMIT = (uint64_t)1e4;
 const uint64_t FDB_VALUE_LENGTH_LIMIT = (uint64_t)1e5;
 
 const uint64_t METADATA_CACHE_SIZE = (uint64_t)100;
+const uint64_t METADATA_INVALID_VERSION = (uint64_t)-1;
 
 const std::string METADATA = "metadata";
 const std::string VERSION_KEY = "version";

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -36,6 +36,7 @@ extern const uint64_t FDB_VALUE_LENGTH_LIMIT;
 
 // Size of metadata cache in entries, number of collections
 extern const uint64_t METADATA_CACHE_SIZE;
+extern const uint64_t METADATA_INVALID_VERSION;
 
 // KVS DocLayer internal keys
 extern const std::string METADATA;

--- a/src/MetadataManager.h
+++ b/src/MetadataManager.h
@@ -57,7 +57,7 @@ struct MetadataManager : ReferenceCounted<MetadataManager>, NonCopyable {
 	                               UID build_id);
 	static IndexInfo indexInfoFromObj(const bson::BSONObj& indexObj, Reference<UnboundCollectionContext> cx);
 
-	std::map<Namespace, std::pair<Reference<UnboundCollectionContext>, uint64_t>> contexts;
+	std::map<Namespace, Reference<UnboundCollectionContext>> metadataCache;
 	DocumentLayer* docLayer;
 };
 

--- a/src/QLContext.h
+++ b/src/QLContext.h
@@ -372,14 +372,24 @@ struct IndexComparator {
 };
 
 struct UnboundCollectionContext : ReferenceCounted<UnboundCollectionContext>, FastAllocated<UnboundCollectionContext> {
-	UnboundCollectionContext(Reference<DirectorySubspace> collectionDirectory,
+	UnboundCollectionContext(uint64_t metadataVersion,
+	                         Reference<DirectorySubspace> collectionDirectory,
 	                         Reference<DirectorySubspace> metadataDirectory)
-	    : collectionDirectory(collectionDirectory), metadataDirectory(metadataDirectory) {
+	    : metadataVersion(metadataVersion),
+	      collectionDirectory(collectionDirectory),
+	      metadataDirectory(metadataDirectory) {
 		cx = Reference<UnboundQueryContext>(new UnboundQueryContext())->getSubContext(collectionDirectory->key());
 	}
 
+	UnboundCollectionContext(Reference<DirectorySubspace> collectionDirectory,
+	                         Reference<DirectorySubspace> metadataDirectory)
+	    : UnboundCollectionContext(DocLayerConstants::METADATA_INVALID_VERSION,
+	                               collectionDirectory,
+	                               metadataDirectory) {}
+
 	UnboundCollectionContext(const UnboundCollectionContext& other)
-	    : collectionDirectory(other.collectionDirectory),
+	    : metadataVersion(other.metadataVersion),
+	      collectionDirectory(other.collectionDirectory),
 	      metadataDirectory(other.metadataDirectory),
 	      simpleIndexMap(other.simpleIndexMap),
 	      knownIndexes(other.knownIndexes),
@@ -399,6 +409,8 @@ struct UnboundCollectionContext : ReferenceCounted<UnboundCollectionContext>, Fa
 	std::string databaseName();
 	std::string collectionName();
 
+	bool isVersioned() { return metadataVersion != DocLayerConstants::METADATA_INVALID_VERSION; }
+
 	Reference<DirectorySubspace> collectionDirectory;
 	Reference<DirectorySubspace> metadataDirectory;
 
@@ -410,6 +422,8 @@ struct UnboundCollectionContext : ReferenceCounted<UnboundCollectionContext>, Fa
 	// This holds all indexes that will be loaded as plugins (i.e. for sets and clears), and should
 	// include indexes that are still building
 	std::vector<IndexInfo> knownIndexes;
+
+	const uint64_t metadataVersion;
 
 private:
 	std::set<std::string> bannedFieldNames;


### PR DESCRIPTION
`UnboundCollectionContext` is an immutable object of collection metadata and it represents a specific version. It makes sense to keep that version information part of it.