### PR TITLE
Resolves #135 Fix the bug where arrays are not stored in a consistent model.

### DIFF
--- a/src/ExtOperator.actor.cpp
+++ b/src/ExtOperator.actor.cpp
@@ -554,9 +554,7 @@ ACTOR static Future<Void> doPopActor(Reference<IReadWriteContext> cx,
 					scx->getSubContext(kp)->clearDescendants();
 					scx->clear(kp);
 					if (oldNumber > 0) {
-						if (next.getSortType() == DVTypeCode::NULL_ELEMENT) {
-							// no-op, so our sparse arrays stay sparse
-						} else if (next.isSimpleType()) {
+						if (next.isSimpleType()) {
 							scx->set(DataValue(oldNumber - 1).encode_key_part(), next.encode_value());
 						} else if (next.getSortType() == DVTypeCode::PACKED_OBJECT) {
 							insertElementRecursive(oldNumber - 1, next.getPackedObject(), scx);
@@ -633,9 +631,7 @@ ACTOR static Future<Void> doPullActor(Reference<IReadWriteContext> cx,
 				if (pulled > 0) {
 					scx->getSubContext(kp)->clearDescendants();
 					scx->clear(kp);
-					if (dontwrite || next.getSortType() == DVTypeCode::NULL_ELEMENT) {
-						// no-op, so our sparse arrays stay sparse
-					} else if (next.isSimpleType()) {
+					if (next.isSimpleType()) {
 						scx->set(DataValue(oldNumber - pulled).encode_key_part(), next.encode_value());
 					} else if (next.getSortType() == DVTypeCode::PACKED_OBJECT) {
 						insertElementRecursive(oldNumber - pulled, next.getPackedObject(), scx);
@@ -810,9 +806,7 @@ ACTOR static Future<Void> doPushActor(Reference<IReadWriteContext> cx,
 								scx->getSubContext(kp)->clearDescendants();
 								scx->clear(kp);
 								if (oldNumber >= skip) {
-									if (next.getSortType() == DVTypeCode::NULL_ELEMENT) {
-										// no-op, so our sparse arrays stay sparse
-									} else if (next.isSimpleType()) {
+									if (next.isSimpleType()) {
 										scx->set(DataValue(oldNumber - skip).encode_key_part(), next.encode_value());
 									} else if (next.getSortType() == DVTypeCode::PACKED_OBJECT) {
 										insertElementRecursive(oldNumber - skip, next.getPackedObject(), scx);

--- a/test/correctness/smoke/test_update.py
+++ b/test/correctness/smoke/test_update.py
@@ -24,7 +24,6 @@
 from collections import OrderedDict
 import pytest
 
-@pytest.mark.xfail
 def test_update_array_containing_none_value(fixture_collection):
     collection = fixture_collection
 


### PR DESCRIPTION
This PR is change the behavior of the doc layer so that it NEVER stores arrays as sparse arrays.

This is to resolve #135.

I run about 20K correctness runs and found no bug caused by this change.