### PR TITLE
Adding more metrics.

### DIFF
--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -65,4 +65,16 @@ const char* INDEX_STATUS_READY = "ready";
 const char* INDEX_STATUS_BUILDING = "building";
 const char* INDEX_STATUS_ERROR = "error";
 
+const char* MT_GUAGE_ACTIVE_CONNECTIONS = "dl_active_connections";
+const char* MT_GUAGE_ACTIVE_CURSORS = "dl_active_cursors";
+const char* MT_HIST_MESSAGE_SZ = "dl_message_size_bytes";
+const char* MT_TIME_QUERY_LATENCY_US = "dl_query_latency_useconds";
+const char* MT_HIST_KEYS_PER_DOCUMENT = "dl_keys_per_doc";
+const char* MT_HIST_DOCUMENT_SZ = "dl_doc_size_bytes";
+const char* MT_HIST_DOCS_PER_INSERT = "dl_docs_per_insert";
+const char* MT_TIME_INSERT_LATENCY_US = "dl_insert_latency_useconds";
+const char* MT_HIST_INSERT_SZ = "dl_insert_size_bytes";
+const char* MT_HIST_TR_PER_REQUEST = "dl_tr_per_request";
+const char* MT_RATE_IDX_REBUILD = "dl_index_rebuild_rate";
+
 } // namespace DocLayerConstants

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -77,6 +77,19 @@ extern const char* INDEX_STATUS_READY;
 extern const char* INDEX_STATUS_BUILDING;
 extern const char* INDEX_STATUS_ERROR;
 
+// Metrics
+extern const char* MT_GUAGE_ACTIVE_CONNECTIONS;
+extern const char* MT_GUAGE_ACTIVE_CURSORS;
+extern const char* MT_HIST_MESSAGE_SZ;
+extern const char* MT_TIME_QUERY_LATENCY_US;
+extern const char* MT_HIST_KEYS_PER_DOCUMENT;
+extern const char* MT_HIST_DOCUMENT_SZ;
+extern const char* MT_HIST_DOCS_PER_INSERT;
+extern const char* MT_TIME_INSERT_LATENCY_US;
+extern const char* MT_HIST_INSERT_SZ;
+extern const char* MT_HIST_TR_PER_REQUEST;
+extern const char* MT_RATE_IDX_REBUILD;
+
 } // namespace DocLayerConstants
 
 #endif // FDB_DOC_LAYER_CONSTANTS_H

--- a/src/DocLayer.actor.cpp
+++ b/src/DocLayer.actor.cpp
@@ -182,7 +182,8 @@ ACTOR Future<Void> extServerConnection(Reference<DocumentLayer> docLayer,
 	state PromiseStream<std::pair<int, Future<Void>>> msg_size_inuse;
 	state Future<Void> onError = ec->bc->onClosed() || popDisposedMessages(bc, msg_size_inuse.getFuture());
 
-	DocumentLayer::metricReporter->captureGauge("activeConnections", ++docLayer->nrConnections);
+	DocumentLayer::metricReporter->captureGauge(DocLayerConstants::MT_GUAGE_ACTIVE_CONNECTIONS,
+	                                            ++docLayer->nrConnections);
 	try {
 		ec->startHousekeeping();
 
@@ -205,8 +206,8 @@ ACTOR Future<Void> extServerConnection(Reference<DocumentLayer> docLayer,
 					Void _ = wait(ec->bc->onBytesAvailable(header->messageLength));
 					auto messageBytes = ec->bc->peekExact(header->messageLength);
 
-					DocumentLayer::metricReporter->captureHistogram("messageLength", header->messageLength);
-					DocumentLayer::metricReporter->captureMeter("messageRate", 1);
+					DocumentLayer::metricReporter->captureHistogram(DocLayerConstants::MT_HIST_MESSAGE_SZ,
+					                                                header->messageLength);
 
 					/* We don't use hdr in this call because the second peek may
 					   have triggered a copy that the first did not, but it's nice
@@ -222,7 +223,8 @@ ACTOR Future<Void> extServerConnection(Reference<DocumentLayer> docLayer,
 			}
 		}
 	} catch (Error& e) {
-		DocumentLayer::metricReporter->captureGauge("activeConnections", --docLayer->nrConnections);
+		DocumentLayer::metricReporter->captureGauge(DocLayerConstants::MT_GUAGE_ACTIVE_CONNECTIONS,
+		                                            --docLayer->nrConnections);
 		return Void();
 	}
 }

--- a/src/ExtUtil.actor.h
+++ b/src/ExtUtil.actor.h
@@ -80,19 +80,19 @@ std::string encodeMaybeDotted(std::string fieldname);
 /**
  * The usual way of inserting an element
  */
-void insertElementRecursive(const bson::BSONElement& elem, Reference<IReadWriteContext> cx);
+int insertElementRecursive(const bson::BSONElement& elem, Reference<IReadWriteContext> cx);
 
 /**
  * An overload that is used only in bizarre cases involving upserting things with compound ids.
  */
-void insertElementRecursive(std::string fn, bson::BSONObj const& obj, Reference<IReadWriteContext> cx);
+int insertElementRecursive(std::string fn, bson::BSONObj const& obj, Reference<IReadWriteContext> cx);
 
 /**
  * Utility overloads used by some of the array update operators
  */
-void insertElementRecursive(int fn, bson::BSONElement const& elem, Reference<IReadWriteContext> cx);
-void insertElementRecursive(int fn, bson::BSONObj const& obj, Reference<IReadWriteContext> cx);
-void insertElementRecursive(int fn, bson::BSONArray const& arr, Reference<IReadWriteContext> cx);
+int insertElementRecursive(int fn, bson::BSONElement const& elem, Reference<IReadWriteContext> cx);
+int insertElementRecursive(int fn, bson::BSONObj const& obj, Reference<IReadWriteContext> cx);
+int insertElementRecursive(int fn, bson::BSONArray const& arr, Reference<IReadWriteContext> cx);
 
 Future<Void> ensureValidObject(const Reference<IReadWriteContext>& cx,
                                const std::string& objectRoot,

--- a/src/QLExpression.actor.cpp
+++ b/src/QLExpression.actor.cpp
@@ -35,7 +35,7 @@ ACTOR Future<Optional<std::pair<Standalone<StringRef>, DataValue>>> getArrayAnce
 		futures.push_back(cx->get(dk.bytes()));
 	}
 
-	if (futures.size()) {
+	if (!futures.empty()) {
 		std::vector<Optional<DataValue>> results = wait(getAll(futures));
 
 		for (int i = 0; i < (checkLast ? results.size() - 1 : results.size()); ++i) {

--- a/test/correctness/smoke/test_update.py
+++ b/test/correctness/smoke/test_update.py
@@ -24,19 +24,21 @@
 from collections import OrderedDict
 import pytest
 
+
 @pytest.mark.xfail
 def test_update_array_containing_none_value(fixture_collection):
     collection = fixture_collection
 
-    collection.insert({'A': [1, None]})
+    collection.insert_one({'A': [1, None]})
 
     docCount = collection.find( {'A': {'$in': [ None]}}).count()
     assert docCount == 1, "Expect 1 documents before the update but got {}".format(docCount)
 
-    collection.update({'A': {'$size': 2}} ,  OrderedDict([('$pop', {'A': -1})]))
+    collection.update_one({'A': {'$size': 2}} ,  OrderedDict([('$pop', {'A': -1})]))
 
     docCount = collection.find( {'A': {'$in': [ None]}}).count()
     assert docCount == 1, "Expect 1 documents after the update but got {}".format(docCount)
+
 
 def test_addToSet_with_none_value(fixture_collection):
     collection = fixture_collection


### PR DESCRIPTION
* Remove `queryRate` and `messageRate`. They are already covered by query latency and message size.
* Changed names to follow Prometheus naming convention
* Added few other metrics