### PR TITLE
Minor cleanup to FDBPlugin and IndexPlugin

### DIFF
--- a/src/QLContext.h
+++ b/src/QLContext.h
@@ -87,7 +87,7 @@ struct DocTransaction : ReferenceCounted<DocTransaction> {
 	// in general. Look at the comments in doNonIsolatedRW() for more on what it's for.
 	void cancel_ongoing_index_reads();
 
-	std::map<std::string, Reference<DocumentDeferred>> infos;
+	std::map<std::string, Reference<DocumentDeferred>> deferredDocuments;
 };
 
 template <class T>


### PR DESCRIPTION
This cleanup came out of review #158. Document keys always contain collection prefix, we have unnecessary extra checks. I have checked the callers of these functions, and it feels like we always pass proper document keys with collection path prefixes. Left couple of `ASSERT` statements, just in case.