### PR TITLE
Fixing FlowLock::take() calls.

### DIFF
--- a/src/QLContext.actor.cpp
+++ b/src/QLContext.actor.cpp
@@ -363,7 +363,7 @@ struct CompoundIndexPlugin : IndexPlugin, ReferenceCounted<CompoundIndexPlugin>,
 				// one finished duplication detecting and index record writing. And thus the following section
 				// before the `lock.release()` call, needs to be protected using a mutex lock.
 				ASSERT(self->flowControlLock.present());
-				Void _ = wait(self->flowControlLock.get()->take(1));
+				Void _ = wait(self->flowControlLock.get()->take());
 				state FlowLock::Releaser releaser(*self->flowControlLock.get(), 1);
 
 				for (; nvv; ++nvv) {
@@ -489,7 +489,7 @@ struct SimpleIndexPlugin : IndexPlugin, ReferenceCounted<SimpleIndexPlugin>, Fas
 				// one finished duplication detecting and index record writing. And thus the following section
 				// before the `lock.release()` call, needs to be protected using a mutex lock.
 				ASSERT(self->flowControlLock.present());
-				Void _ = wait(self->flowControlLock.get()->take(1));
+				Void _ = wait(self->flowControlLock.get()->take());
 				state FlowLock::Releaser releaser(*self->flowControlLock.get(), 1);
 
 				for (const DataValue& v : new_values) {


### PR DESCRIPTION
`take(1)` doesn't just acquire one permit, instead, it acquires a permit
with the lowest priority possible. The first argument of `take()` is not the number
of permits, but task priority

This helps #162 a bit. Not a complete fix.