### PR TITLE
Fix for compound index selection.

### DIFF
--- a/src/QLContext.h
+++ b/src/QLContext.h
@@ -368,7 +368,10 @@ struct IndexInfo {
 };
 
 struct IndexComparator {
-	bool operator()(const IndexInfo& lhs, const IndexInfo& rhs) { return lhs.indexKeys.size() < rhs.indexKeys.size(); }
+	bool operator()(const IndexInfo& lhs, const IndexInfo& rhs) {
+		return lhs.indexKeys.size() == rhs.indexKeys.size() ? lhs.indexName < rhs.indexName
+		                                                    : lhs.indexKeys.size() < rhs.indexKeys.size();
+	}
 };
 
 struct UnboundCollectionContext : ReferenceCounted<UnboundCollectionContext>, FastAllocated<UnboundCollectionContext> {


### PR DESCRIPTION
Doc Layer maintains indexes with two level map. The first level to identify simple indexes and second level for compound indexes. Set that maintains the compound indexes with the same prefix are has the wrong comparator that matches the indexes of the same size. This patch fixes the comparator.

Thankfully this structure is not used in the write path, otherwise, we will have to rebuild the indexes.