### PR TITLE
Make `IndexInfo` `ReferenceCounted`

### DIFF
--- a/src/MetadataManager.h
+++ b/src/MetadataManager.h
@@ -55,7 +55,7 @@ struct MetadataManager : ReferenceCounted<MetadataManager>, NonCopyable {
 	                               Standalone<StringRef> encodedIndexId,
 	                               Reference<struct ExtConnection> ec,
 	                               UID build_id);
-	static IndexInfo indexInfoFromObj(const bson::BSONObj& indexObj, Reference<UnboundCollectionContext> cx);
+	static Reference<IndexInfo> indexInfoFromObj(const bson::BSONObj& indexObj, Reference<UnboundCollectionContext> cx);
 
 	std::map<Namespace, Reference<UnboundCollectionContext>> metadataCache;
 	DocumentLayer* docLayer;

--- a/src/QLPlan.actor.h
+++ b/src/QLPlan.actor.h
@@ -235,7 +235,7 @@ private:
 
 struct IndexScanPlan : ConcretePlan<IndexScanPlan> {
 	IndexScanPlan(Reference<UnboundCollectionContext> cx,
-	              IndexInfo index,
+	              Reference<IndexInfo> index,
 	              Optional<std::string> begin,
 	              Optional<std::string> end,
 	              std::vector<std::string> matchedPrefix)
@@ -246,7 +246,7 @@ struct IndexScanPlan : ConcretePlan<IndexScanPlan> {
 		return BSON(
 		    // clang-format off
 			"type" << "index scan" <<
-			"index name" << index.indexName <<
+			"index name" << index->indexName <<
 			"bounds" << BSON(
 				"begin" << bound_begin <<
 				"end" << bound_end)
@@ -262,7 +262,7 @@ struct IndexScanPlan : ConcretePlan<IndexScanPlan> {
 
 private:
 	Reference<UnboundCollectionContext> cx;
-	IndexInfo index;
+	Reference<IndexInfo> index;
 	Optional<std::string> begin;
 	Optional<std::string> end;
 
@@ -634,13 +634,13 @@ struct IndexInsertPlan : ConcretePlan<IndexInsertPlan> {
 
 struct BuildIndexPlan : ConcretePlan<BuildIndexPlan> {
 	Reference<Plan> scan;
-	IndexInfo index;
+	Reference<IndexInfo> index;
 	std::string dbName;
 	Standalone<StringRef> encodedIndexId;
 	Reference<MetadataManager> mm;
 
 	BuildIndexPlan(Reference<Plan> scan,
-	               IndexInfo index,
+	               Reference<IndexInfo> index,
 	               std::string const& dbName,
 	               Standalone<StringRef> encodedIndexId,
 	               Reference<MetadataManager> mm)


### PR DESCRIPTION
Avoid lots of copies in `MetadataManager` index selection, which happens on each and every request.