### PR TITLE
Resolves #39: Replacing usage of `std::string` with `StringRef` for `Datakey` and `DataValue`

### DIFF
--- a/src/ExtCmd.actor.cpp
+++ b/src/ExtCmd.actor.cpp
@@ -848,8 +848,9 @@ ACTOR static Future<Reference<ExtMsgReply>> doGetKVStatusActor(Reference<ExtConn
 		Optional<FDB::FDBStandalone<StringRef>> status = wait(dtr->tr->get(statusKey));
 		if (status.present()) {
 			const DataValue vv = DataValue::decode_value(status.get());
-			reply->addDocument(BSON("ok" << 1.0 << "jsonValue"
-			                             << vv.encode_value().c_str()) /*bson::fromjson(vv.encode_value().c_str())*/);
+			reply->addDocument(
+			    BSON("ok" << 1.0 << "jsonValue"
+			              << vv.encode_value().toString()) /*bson::fromjson(vv.encode_value().c_str())*/);
 		}
 	} catch (Error& e) {
 		reply->addDocument(

--- a/src/ExtCmd.actor.cpp
+++ b/src/ExtCmd.actor.cpp
@@ -93,7 +93,7 @@ ACTOR static Future<std::pair<int, int>> dropIndexMatching(Reference<DocTransact
 
 	wait(matchingIndex->commitChanges());
 
-	Key indexKey = targetedCollection->getIndexesSubspace().withSuffix(StringRef(encodeMaybeDotted(matchingName)));
+	Key indexKey = targetedCollection->getIndexesSubspace().withSuffix(encodeMaybeDotted(matchingName));
 	tr->tr->clear(FDB::KeyRangeRef(indexKey, strinc(indexKey)));
 
 	targetedCollection->bindCollectionContext(tr)->bumpMetadataVersion();

--- a/src/ExtMsg.actor.cpp
+++ b/src/ExtMsg.actor.cpp
@@ -877,7 +877,7 @@ ACTOR Future<WriteCmdResult> doInsertCmd(Namespace ns,
 	}
 
 	std::vector<Reference<IInsertOp>> inserts;
-	std::set<std::string> ids;
+	std::set<Standalone<StringRef>> ids;
 	int insertSize = 0;
 	for (const auto& d : *documents) {
 		const bson::BSONObj& obj = d;

--- a/src/ExtOperator.actor.cpp
+++ b/src/ExtOperator.actor.cpp
@@ -529,7 +529,7 @@ ACTOR static Future<Void> doPopActor(Reference<IReadWriteContext> cx,
 		length = 0;
 
 	state Reference<IReadWriteContext> scx = cx->getSubContext(path);
-	state std::string kp;
+	state Standalone<StringRef> kp;
 
 	if (element.number() == 1) {
 		if (length > 0) {
@@ -625,7 +625,7 @@ ACTOR static Future<Void> doPullActor(Reference<IReadWriteContext> cx,
 		loop {
 			try {
 				DataValue next = waitNext(f);
-				std::string kp = DataValue(oldNumber).encode_key_part();
+				Standalone<StringRef> kp = DataValue(oldNumber).encode_key_part();
 				bool dontwrite = false;
 				if (uniques.find(next) != uniques.end()) {
 					pulled++;
@@ -769,7 +769,7 @@ ACTOR static Future<Void> doPushActor(Reference<IReadWriteContext> cx,
 				if (slice > 0) {
 					if (slice < length) {
 						for (int n = slice; n < length; ++n) {
-							std::string kp = DataValue(n).encode_key_part();
+							Standalone<StringRef> kp = DataValue(n).encode_key_part();
 							scx->getSubContext(kp)->clearDescendants();
 							scx->clear(kp);
 						}
@@ -809,7 +809,7 @@ ACTOR static Future<Void> doPushActor(Reference<IReadWriteContext> cx,
 						loop {
 							try {
 								DataValue next = waitNext(f2);
-								std::string kp = DataValue(oldNumber).encode_key_part();
+								Standalone<StringRef> kp = DataValue(oldNumber).encode_key_part();
 								scx->getSubContext(kp)->clearDescendants();
 								scx->clear(kp);
 								if (oldNumber >= skip) {

--- a/src/ExtUtil.actor.cpp
+++ b/src/ExtUtil.actor.cpp
@@ -51,7 +51,7 @@ std::string getLastPart(std::string maybeDottedFieldName) {
 }
 
 Key encodeMaybeDotted(std::string fieldname) {
-	if (fieldname.compare("") == 0)
+	if (fieldname.empty())
 		return StringRef(fieldname);
 
 	std::string path;
@@ -203,7 +203,7 @@ ACTOR Future<Void> ensureValidObject(Reference<IReadWriteContext> cx,
 		}
 	} else if (createRoot) {
 		cx->set(encodedObjectRoot, DataValue::subObject().encode_value());
-		if (upOneLevel(objectRoot) != "") {
+		if (!upOneLevel(objectRoot).empty()) {
 			wait(ensureValidObject(cx, upOneLevel(objectRoot), getLastPart(objectRoot), createRoot));
 		}
 	}
@@ -240,7 +240,7 @@ Projection::Iterator& Projection::Iterator::operator++() {
 		return *this;
 	}
 
-	while (stack.size() &&
+	while (!stack.empty() &&
 	       (stack.back().itr == stack.back().projection->fields.end() || stack.back().projection->shouldBeRead)) {
 		if (stack.back().itr == stack.back().projection->fields.end()) {
 			stack.pop_back();
@@ -252,7 +252,7 @@ Projection::Iterator& Projection::Iterator::operator++() {
 		}
 	}
 
-	if (stack.size()) {
+	if (!stack.empty()) {
 		path.push_back(stack.back().itr->first);
 		StackEntry newEntry = StackEntry(stack.back().itr->second);
 		++stack.back().itr;
@@ -276,7 +276,7 @@ Projection::Iterator Projection::begin() {
 	Reference<Projection> root = Reference<Projection>::addRef(this);
 
 	Projection::Iterator itr;
-	itr.stack.push_back(Iterator::StackEntry(root));
+	itr.stack.emplace_back(root);
 
 	return ++itr;
 }
@@ -293,7 +293,7 @@ std::string Projection::debugString(bool first) {
 
 	s << "{";
 	bool addComma = false;
-	for (auto itr : fields) {
+	for (const auto& itr : fields) {
 		if (addComma)
 			s << ", ";
 		else
@@ -338,7 +338,7 @@ Projector::IncludeType Projector::includeNextField(int depth, std::string fieldN
 		else {
 			auto itr = currentProjection->fields.find(fieldName);
 			if (itr != currentProjection->fields.end()) {
-				projectionStack.push_back(std::make_pair(fieldName, itr->second));
+				projectionStack.emplace_back(fieldName, itr->second);
 			}
 		}
 	}
@@ -392,7 +392,7 @@ ACTOR Future<Void> getArrayStream(Reference<IReadWriteContext> document,
 				auto popped = std::move(bobs.back());
 				bobs.pop_back();
 				if (popped.isArrayLength >= 0) {
-					if (bobs.size())
+					if (!bobs.empty())
 						bobs.back().append(popped.fieldname, DataValue(bson::BSONArray(popped.build())));
 					else {
 						ASSERT(i == dk.size() - 1);
@@ -400,7 +400,7 @@ ACTOR Future<Void> getArrayStream(Reference<IReadWriteContext> document,
 						currentLoc++;
 					}
 				} else {
-					if (bobs.size())
+					if (!bobs.empty())
 						bobs.back().append(popped.fieldname, DataValue(popped.build()));
 					else {
 						ASSERT(i == dk.size() - 1);
@@ -411,7 +411,7 @@ ACTOR Future<Void> getArrayStream(Reference<IReadWriteContext> document,
 			}
 
 			DataValue kdv = DataValue::decode_key_part(dk[dk.size() - 1]);
-			if (!bobs.size()) {
+			if (bobs.empty()) {
 				ASSERT(kdv.getSortType() == DVTypeCode::NUMBER);
 				int j = kdv.getDouble();
 				for (; currentLoc < j; ++currentLoc) {
@@ -423,13 +423,13 @@ ACTOR Future<Void> getArrayStream(Reference<IReadWriteContext> document,
 			DataValue dv = DataValue::decode_value(kv.value);
 			switch (dv.getBSONType()) {
 			case bson::BSONType::Object:
-				bobs.push_back(BOBObj(-1, fieldname));
+				bobs.emplace_back(-1, fieldname);
 				break;
 			case bson::BSONType::Array:
-				bobs.push_back(BOBObj(dv.getArraysize(), fieldname));
+				bobs.emplace_back(dv.getArraysize(), fieldname);
 				break;
 			default: {
-				if (bobs.size())
+				if (!bobs.empty())
 					bobs.back().append(fieldname, dv);
 				else {
 					p.send(dv);
@@ -445,7 +445,7 @@ ACTOR Future<Void> getArrayStream(Reference<IReadWriteContext> document,
 		}
 	}
 
-	if (bobs.size()) {
+	if (!bobs.empty()) {
 		for (auto i = bobs.size() - 1; i > 0; --i) {
 			if (bobs[i].isArrayLength >= 0) {
 				bobs[i - 1].append(bobs[i].fieldname, DataValue(bson::BSONArray(bobs[i].build())));
@@ -507,8 +507,8 @@ Reference<IPredicate> eq_predicate(const bson::BSONElement& el, const std::strin
 }
 
 Reference<IPredicate> re_predicate(const bson::BSONElement& el, const std::string& prefix) {
-	std::string regexPattern = "";
-	std::string regexOptions = "";
+	std::string regexPattern;
+	std::string regexOptions;
 	if (el.type() == bson::BSONType::RegEx) {
 		regexPattern = el.regex();
 		regexOptions = el.regexFlags();
@@ -689,7 +689,7 @@ bson::BSONObj transformOperatorQueryToUpdatableDocument(bson::BSONObj selector, 
 				else if (fieldName == "$all") {
 					if (next.type() != bson::BSONType::Array || next.Array().size() > 1)
 						throw invalid_query_operator();
-					else if (next.Array().size())
+					else if (!next.Array().empty())
 						builder.appendAs(next.Array()[0], bson::StringData(parentKey));
 				} else if (fieldName == "$elemMatch")
 					stop = true;
@@ -888,7 +888,7 @@ Reference<Projection> parseProjection(bson::BSONObj const& fieldSelector) {
 					Reference<Projection>* current = &root;
 					do {
 						prev = pos + 1;
-						pos = fieldName.find(".", prev);
+						pos = fieldName.find('.', prev);
 						current = &(*current)->fields[fieldName.substr(prev, std::max(pos - prev, (size_t)1))];
 						if (!*current) {
 							*current = Reference<Projection>(new Projection());
@@ -896,7 +896,7 @@ Reference<Projection> parseProjection(bson::BSONObj const& fieldSelector) {
 
 						// The last field in the fieldName spec should be included iff the element was inclusive. All
 						// others should be the opposite.
-						if (pos == fieldName.npos) {
+						if (pos == std::string::npos) {
 							(*current)->included = elIncluded;
 						} else {
 							(*current)->included = !elIncluded;

--- a/src/ExtUtil.actor.cpp
+++ b/src/ExtUtil.actor.cpp
@@ -760,11 +760,11 @@ Optional<IdInfo> extractEncodedIds(bson::BSONObj obj) {
 			throw no_array_id();
 		} else if (el.isABSONObj()) {
 			encodedId = DataValue(sortBsonObj(el.Obj())).encode_key_part();
-			valueEncodedId = DataValue::subObject().encode_value();
+			valueEncodedId = DataValue::subObject().encode_value().toString();
 			idObj = el.Obj().getOwned();
 		} else {
 			encodedId = DataValue(el).encode_key_part();
-			valueEncodedId = DataValue(el).encode_value();
+			valueEncodedId = DataValue(el).encode_value().toString();
 			idObj = Optional<bson::BSONObj>();
 		}
 		encodedIds = IdInfo(encodedId, valueEncodedId, idObj);

--- a/src/ExtUtil.actor.h
+++ b/src/ExtUtil.actor.h
@@ -41,11 +41,11 @@ Reference<T> ref(T* newVal) {
 }
 
 struct IdInfo {
-	std::string keyEncoded;
-	std::string valueEncoded;
+	Standalone<StringRef> keyEncoded;
+	Standalone<StringRef> valueEncoded;
 	Optional<bson::BSONObj> objValue;
 
-	IdInfo(std::string keyEncoded, std::string valueEncoded, Optional<bson::BSONObj> objValue)
+	IdInfo(Standalone<StringRef> keyEncoded, Standalone<StringRef> valueEncoded, Optional<bson::BSONObj> objValue)
 	    : keyEncoded(keyEncoded), valueEncoded(valueEncoded), objValue(objValue) {}
 };
 
@@ -76,7 +76,7 @@ bson::BSONObj transformOperatorQueryToUpdatableDocument(bson::BSONObj selector,
 
 std::string upOneLevel(std::string maybeDottedFieldName);
 std::string getLastPart(std::string maybeDottedFieldName);
-std::string encodeMaybeDotted(std::string fieldname);
+Key encodeMaybeDotted(std::string fieldname);
 
 /**
  * The usual way of inserting an element

--- a/src/MetadataManager.actor.cpp
+++ b/src/MetadataManager.actor.cpp
@@ -31,9 +31,9 @@ std::string fullCollNameToString(Namespace const& ns) {
 }
 
 Future<uint64_t> getMetadataVersion(Reference<DocTransaction> tr, Reference<DirectorySubspace> metadataDirectory) {
-	std::string versionKey = metadataDirectory->key().toString() +
-	                         DataValue(DocLayerConstants::VERSION_KEY, DVTypeCode::STRING).encode_key_part();
-	Future<Optional<FDBStandalone<StringRef>>> fov = tr->tr->get(StringRef(versionKey));
+	Standalone<StringRef> versionKey = metadataDirectory->key().withSuffix(
+	    DataValue(DocLayerConstants::VERSION_KEY, DVTypeCode::STRING).encode_key_part());
+	Future<Optional<FDBStandalone<StringRef>>> fov = tr->tr->get(versionKey);
 	Future<uint64_t> ret = map(fov, [](Optional<FDBStandalone<StringRef>> ov) -> uint64_t {
 		if (!ov.present())
 			return 0;

--- a/src/QLContext.actor.cpp
+++ b/src/QLContext.actor.cpp
@@ -693,8 +693,8 @@ void UnboundCollectionContext::addIndex(Reference<IndexInfo> info) {
 }
 
 Key UnboundCollectionContext::getIndexesSubspace() {
-	return Standalone<StringRef>(metadataDirectory->key().toString() +
-	                             DataValue(std::string(DocLayerConstants::INDICES_KEY)).encode_key_part());
+	return metadataDirectory->key().withSuffix(
+	    DataValue(DocLayerConstants::INDICES_KEY, DVTypeCode::STRING).encode_key_part());
 }
 
 Reference<UnboundQueryContext> UnboundCollectionContext::getIndexesContext() {
@@ -729,8 +729,8 @@ Optional<Reference<IndexInfo>> UnboundCollectionContext::getCompoundIndex(std::v
 }
 
 Key UnboundCollectionContext::getVersionKey() {
-	return Key(KeyRef(metadataDirectory->key().toString() +
-	                  DataValue(DocLayerConstants::VERSION_KEY, DVTypeCode::STRING).encode_key_part()));
+	return metadataDirectory->key().withSuffix(
+	    DataValue(DocLayerConstants::VERSION_KEY, DVTypeCode::STRING).encode_key_part());
 }
 
 std::string UnboundCollectionContext::databaseName() {
@@ -795,8 +795,8 @@ IndexInfo::IndexInfo(std::string indexName,
                      Optional<UID> buildId,
                      bool isUniqueIndex)
     : indexName(indexName), indexKeys(indexKeys), status(status), buildId(buildId), isUniqueIndex(isUniqueIndex) {
-	encodedIndexName = DataValue(indexName, DVTypeCode::STRING).encode_key_part();
-	indexCx = collectionCx->getIndexesContext()->getSubContext(encodedIndexName);
+	indexCx =
+	    collectionCx->getIndexesContext()->getSubContext(DataValue(indexName, DVTypeCode::STRING).encode_key_part());
 	multikey = true;
 }
 

--- a/src/QLContext.actor.cpp
+++ b/src/QLContext.actor.cpp
@@ -108,7 +108,7 @@ protected:
 	~ITDoc() = default;
 };
 
-static std::string getFDBKey(DataKey const& key, int extraReserveBytes = 0) {
+static string getFDBKey(DataKey const& key) {
 	return key.toString();
 }
 
@@ -139,7 +139,7 @@ ACTOR static Future<Void> FDBPlugin_getDescendants(DataKey key,
                                                    Standalone<StringRef> relEnd,
                                                    PromiseStream<KeyValue> output,
                                                    Reference<FlowLock> flowControlLock) {
-	std::string prefix = getFDBKey(key, relEnd.size());
+	std::string prefix = getFDBKey(key);
 	state int substrOffset = static_cast<int>(prefix.size());
 	state std::string begin = strAppend(prefix, relBegin);
 	state std::string end = std::move(prefix);
@@ -718,7 +718,7 @@ Optional<Reference<IndexInfo>> UnboundCollectionContext::getCompoundIndex(std::v
 		return Optional<Reference<IndexInfo>>();
 	auto indexV = simpleIndexMap.find(prefix[0]);
 	ASSERT(indexV != simpleIndexMap.end());
-	for (Reference<IndexInfo> index : indexV->second) {
+	for (const Reference<IndexInfo>& index : indexV->second) {
 		if (index->size() > prefix.size() && index->hasPrefix(prefix)) {
 			if (index->indexKeys[prefix.size()].first == nextIndexKey) {
 				return index;

--- a/src/QLContext.h
+++ b/src/QLContext.h
@@ -192,7 +192,7 @@ protected:
 	bson::BSONObj obj;
 	bool isArray;
 
-	std::string fieldNameToKeyPart(StringRef fn) {
+	Standalone<StringRef> fieldNameToKeyPart(StringRef fn) {
 		if (isArray || std::all_of(fn.begin(), fn.end(), ::isdigit)) {
 			return DataValue(atoi(fn.toString().c_str())).encode_key_part();
 		} else
@@ -215,7 +215,7 @@ protected:
 			bson::BSONElement el = i.next();
 			StringRef name((uint8_t*)el.fieldName(), el.fieldNameSize());
 
-			auto key = prefix.toString() + fieldNameToKeyPart(name);
+			auto key = prefix.withSuffix(fieldNameToKeyPart(name));
 			if (key >= begin && key < end) {
 				out.send(FDB::KeyValueRef(key, DataValue(el).encode_value()));
 			}
@@ -342,7 +342,6 @@ struct IndexInfo : ReferenceCounted<IndexInfo>, FastAllocated<IndexInfo> {
 	enum IndexStatus { READY = 0, BUILDING = 1000, INVALID = 9999 };
 
 	std::string indexName;
-	std::string encodedIndexName;
 	Reference<UnboundQueryContext> indexCx;
 	std::vector<std::pair<std::string, int>> indexKeys;
 	IndexStatus status;

--- a/src/QLExpression.h
+++ b/src/QLExpression.h
@@ -53,7 +53,7 @@ struct IExpression {
 	virtual std::string get_index_key() const { return {}; }
 };
 
-std::string encodeMaybeDotted(std::string fieldname);
+Key encodeMaybeDotted(std::string fieldname);
 /**
  * This expression implements a MongoDB dot-separated path expansion (it returns all subdocuments
  * patching the given path, expanding arrays as necessary).
@@ -72,7 +72,7 @@ struct ExtPathExpression : IExpression, ReferenceCounted<ExtPathExpression>, Fas
 
 	ExtPathExpression(std::string const& strPath, bool const& expandLastArray, bool const& imputeNulls)
 	    : strPath(strPath), expandLastArray(expandLastArray), imputeNulls(imputeNulls) {
-		path = StringRef(encodeMaybeDotted(strPath));
+		path = encodeMaybeDotted(strPath);
 	}
 
 	GenFutureStream<Reference<IReadContext>> evaluate(Reference<IReadContext> const& document) override;

--- a/src/QLExpression.h
+++ b/src/QLExpression.h
@@ -42,12 +42,6 @@ struct IExpression {
 	virtual std::string toString() const = 0;
 
 	/**
-	 * Bounds on the number of subdocuments that evaluate() could return (for any input)
-	 */
-	virtual int min_results() const { return 0; }
-	virtual int max_results() const { return std::numeric_limits<int>::max(); }
-
-	/**
 	 * Return the name of the index which, if it exists, indexes by the values of this expression
 	 */
 	virtual std::string get_index_key() const { return {}; }

--- a/src/QLPlan.actor.h
+++ b/src/QLPlan.actor.h
@@ -236,8 +236,8 @@ private:
 struct IndexScanPlan : ConcretePlan<IndexScanPlan> {
 	IndexScanPlan(Reference<UnboundCollectionContext> cx,
 	              Reference<IndexInfo> index,
-	              Optional<std::string> begin,
-	              Optional<std::string> end,
+	              Optional<Key> begin,
+	              Optional<Key> end,
 	              std::vector<std::string> matchedPrefix)
 	    : cx(cx), index(index), begin(begin), end(end), matchedPrefix(matchedPrefix) {}
 	bson::BSONObj describe() override {
@@ -263,8 +263,8 @@ struct IndexScanPlan : ConcretePlan<IndexScanPlan> {
 private:
 	Reference<UnboundCollectionContext> cx;
 	Reference<IndexInfo> index;
-	Optional<std::string> begin;
-	Optional<std::string> end;
+	Optional<Key> begin;
+	Optional<Key> end;
 
 	// Matched index not necessarily the exact match. This plan could simply use prefix of index.
 	// For now, index direction is not honored by Doc Layer, probably SOMEDAY

--- a/src/QLPredicate.actor.cpp
+++ b/src/QLPredicate.actor.cpp
@@ -79,9 +79,7 @@ void NonePredicate::simplify_and(SimplifyAndContext& cx) {
 	cx.isNone = true;
 }
 
-ACTOR static Future<bool> doAndEvaluate(std::vector<Reference<IPredicate>> terms,
-                                        Reference<IReadContext> context,
-                                        bool expandArrays) {
+ACTOR static Future<bool> doAndEvaluate(std::vector<Reference<IPredicate>> terms, Reference<IReadContext> context) {
 	// Short-circuit, could be parallel instead?
 
 	for (const auto& term : terms) {
@@ -94,7 +92,7 @@ ACTOR static Future<bool> doAndEvaluate(std::vector<Reference<IPredicate>> terms
 }
 
 Future<bool> AndPredicate::evaluate(Reference<IReadContext> const& context) {
-	return doAndEvaluate(terms, context, true);
+	return doAndEvaluate(terms, context);
 }
 
 void AndPredicate::simplify_and(SimplifyAndContext& cx) {
@@ -135,7 +133,7 @@ Reference<IPredicate> AndPredicate::simplify() {
 std::string AndPredicate::toString() {
 	std::string s = "AND(";
 	int addcomma = 0;
-	for (auto t : terms) {
+	for (const auto& t : terms) {
 		if (addcomma++)
 			s += ", ";
 		s += t->toString();
@@ -154,9 +152,7 @@ Reference<IPredicate> AndPredicate::simplify_not() {
 	return OrPredicate(terms).simplify();
 }
 
-ACTOR Future<bool> doOrEvaluate(std::vector<Reference<IPredicate>> terms,
-                                Reference<IReadContext> context,
-                                bool expandArrays) {
+ACTOR Future<bool> doOrEvaluate(std::vector<Reference<IPredicate>> terms, Reference<IReadContext> context) {
 	state std::vector<Future<bool>> ets;
 	for (const auto& term : terms) {
 		Future<bool> et = term->evaluate(context);
@@ -180,7 +176,7 @@ Future<bool> OrPredicate::evaluate(Reference<IReadContext> const& context) {
 
 	// or ...
 
-	return doOrEvaluate(terms, context, true);
+	return doOrEvaluate(terms, context);
 }
 
 Reference<IPredicate> OrPredicate::simplify() {
@@ -296,13 +292,13 @@ void EqPredicate::simplify_and(SimplifyAndContext& cx) {
 		cx.rangeLike = range_equiv;
 }
 
-ACTOR Future<bool> doNotEvaluate(Reference<IPredicate> term, Reference<IReadContext> context, bool expandArrays) {
+ACTOR Future<bool> doNotEvaluate(Reference<IPredicate> term, Reference<IReadContext> context) {
 	bool et = wait(term->evaluate(context));
 	return !et;
 }
 
 Future<bool> NotPredicate::evaluate(Reference<IReadContext> const& context) {
-	return doNotEvaluate(term, context, true);
+	return doNotEvaluate(term, context);
 }
 
 Reference<IPredicate> NotPredicate::simplify() {

--- a/src/QLProjection.actor.h
+++ b/src/QLProjection.actor.h
@@ -125,8 +125,8 @@ ACTOR Future<Optional<DataValue>> getMaybeRecursiveIfPresent(
     Reference<IReadContext> cx,
     Reference<Projection> projection = Reference<Projection>());
 ACTOR Future<DataValue> getMaybeRecursive(Reference<IReadContext> cx, StringRef path);
-ACTOR Future<DataValue> getRecursiveKnownPresent(Reference<IReadContext> cx,
-                                                 Reference<Projection> projection = Reference<Projection>());
+Future<DataValue> getRecursiveKnownPresent(Reference<IReadContext> const& cx,
+                                           Reference<Projection> const& projection = Reference<Projection>());
 
 // Parse a Projection tree from a BSON projection specification
 Reference<Projection> parseProjection(bson::BSONObj const& fieldSelector); // FIXME: Where does this belong?

--- a/src/QLTypes.cpp
+++ b/src/QLTypes.cpp
@@ -143,8 +143,8 @@ std::string DataValue::encode_key_part() const {
 	}
 }
 
-std::string DataValue::encode_value() const {
-	return representation.toString();
+StringRef DataValue::encode_value() const {
+	return representation;
 }
 
 DataValue DataValue::decode_key_part(StringRef key) {

--- a/src/QLTypes.cpp
+++ b/src/QLTypes.cpp
@@ -129,17 +129,17 @@ static std::string unescape_nulls(StringRef key) {
 	return s;
 }
 
-std::string DataValue::encode_key_part() const {
+Standalone<StringRef> DataValue::encode_key_part() const {
 	switch (getSortType()) {
 	case DVTypeCode::NUMBER:
-		return representation.substr(0, 11).toString();
+		return representation.substr(0, 11);
 	case DVTypeCode::STRING:
-		return escape_nulls();
+		return StringRef(escape_nulls());
 	case DVTypeCode::PACKED_ARRAY:
 	case DVTypeCode::PACKED_OBJECT:
-		return escape_nulls();
+		return StringRef(escape_nulls());
 	default:
-		return representation.toString();
+		return representation.contents(); // Force a copy
 	}
 }
 

--- a/src/QLTypes.h
+++ b/src/QLTypes.h
@@ -117,7 +117,7 @@ struct DataValue {
 
 	int compare(DataValue const& other) const;
 
-	std::string encode_key_part() const;
+	Standalone<StringRef> encode_key_part() const;
 	StringRef encode_value() const;
 
 	static DataValue decode_key_part(StringRef nonNumKey);

--- a/src/QLTypes.h
+++ b/src/QLTypes.h
@@ -118,7 +118,7 @@ struct DataValue {
 	int compare(DataValue const& other) const;
 
 	std::string encode_key_part() const;
-	std::string encode_value() const;
+	StringRef encode_value() const;
 
 	static DataValue decode_key_part(StringRef nonNumKey);
 	static DataValue decode_key_part(StringRef numKey, bson::BSONType numCode);


### PR DESCRIPTION
For the following reasons its bad to use `std::string` for bytes

* Usage of `std::string` for bytes is confusing
* Implicit conversion from `std::string` to `StringRef` is dangerous, especially if `std::string` is r-value
* Implicit conversion from `std::string` to `Standalone<StringRef>` is unnecessary extra copy. This is happening a lot.
* Most of the places `std::string` is passed back to `FDB::Transaction::get()` or `FDB::Transaction::set()`, which convert it to `StringRef` anyway. Semantics are very confusing.

Resolves #39, even though we still have some bad usages of `std::string`, the majority are changed.