### PR TITLE
Resolves issue #16: Added return statements

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,7 +122,7 @@ target_compile_options(fdbdoc
             -Werror
             -Wno-error=format
             -Wno-deprecated
-            # -Wreturn-type
+            -Wreturn-type
             -fvisibility=hidden
             -fno-omit-frame-pointer
         )

--- a/src/ConsoleMetric.actor.cpp
+++ b/src/ConsoleMetric.actor.cpp
@@ -141,6 +141,9 @@ MetricStat& MetricStat::captureNewValue(int64_t val) {
 			sum += val;
 			avg = (double)sum / (double)count;
 			return *this;
+		default:
+			// Issue #16: Added default return statement to fix the warning during compilation
+			return *this;
 		}
 	}
 }

--- a/src/QLPlan.actor.cpp
+++ b/src/QLPlan.actor.cpp
@@ -247,9 +247,9 @@ Optional<Reference<Plan>> IndexScanPlan::push_down(Reference<UnboundCollectionCo
 		default:
 			return Optional<Reference<Plan>>();
 		}
-	} else {
-		return Optional<Reference<Plan>>();
 	}
+	// Issue #16: Added return statement in right place to fix the warning during compilation
+	return Optional<Reference<Plan>>();
 }
 
 ACTOR static Future<Void> doFilter(PlanCheckpoint* checkpoint,


### PR DESCRIPTION
This PR resolves an issue [#16](https://github.com/FoundationDB/fdb-document-layer/issues/16)
Added return statements at 2 functions which were causing warning when wreturn-type is enabled