### PR TITLE
Resolves #120: Cleaned code to use generic function for reporting error messages

### DIFF
--- a/src/ExtMsg.actor.h
+++ b/src/ExtMsg.actor.h
@@ -113,22 +113,20 @@ struct ExtMsgReply : ExtMsg, FastAllocated<ExtMsgReply> {
 		replyHeader.documentCount++;
 	}
 
-	void setError(std::string msg, int code) {
+	void setError(std::string msg, int code, std::string errmsg) {
 		// Clear if response contains any outstanding documents
 		documents.clear();
 		replyHeader.documentCount = 0;
 
-		// Set query failure flag
-		addResponseFlag(2);
-
 		// clang-format off
 		addDocument(BSON("ok" << 0 <<
 		                 "$err" << msg <<
-		                 "code" << code));
+		                 "code" << code <<
+				 "errmsg" << errmsg));
 		// clang-format on
 	}
 
-	void setError(Error e) { setError(e.what(), e.code()); }
+	void setError(Error e) { setError(e.name(), e.code(), e.what()); }
 
 	void setResponseFlags(int32_t flags) { replyHeader.responseFlags = flags; }
 

--- a/src/error_definitions.h
+++ b/src/error_definitions.h
@@ -85,6 +85,13 @@ DOCLAYER_ERROR(wire_protocol_mismatch, 29966, "Wire protocol mismatch. Bad messa
 DOCLAYER_ERROR(no_index_name, 29967, "No index name specified");
 DOCLAYER_ERROR(unsupported_index_type, 29969, "Document Layer does not support this index type, yet.");
 
+DOCLAYER_ERROR(access_denied_use_admin_db, 29972, "access denied; use admin db");
+DOCLAYER_ERROR(not_really_talking_to_mongodb, 29973, "not really talking to mongodb");
+DOCLAYER_ERROR(index_must_be_a_string_or_an_object, 29974, "'index' must be a string or an object");
+DOCLAYER_ERROR(unsupported_fdb_version_for_kvstatus,
+               29975,
+               "This command is supported only with version 3.0 and above of the KV Store, if you are using an older "
+               "FDB version please use the fdbcli utility to check its status.");
 DOCLAYER_ERROR(collection_name_does_not_exist, 29976, "Collection name does not exist.");
 DOCLAYER_ERROR(collection_name_already_exist, 29977, "Collection name already exist.");
 DOCLAYER_ERROR(old_and_new_collection_name_cannot_be_same, 29978, "Old and New collection name cannot be same.");


### PR DESCRIPTION
This PR resolves [#120](https://github.com/FoundationDB/fdb-document-layer/issues/120)  

Cleanup the error reporting code with generic format and function. 