### PR TITLE
More metrics

### DIFF
--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -76,5 +76,7 @@ const char* MT_TIME_INSERT_LATENCY_US = "dl_insert_latency_useconds";
 const char* MT_HIST_INSERT_SZ = "dl_insert_size_bytes";
 const char* MT_HIST_TR_PER_REQUEST = "dl_tr_per_request";
 const char* MT_RATE_IDX_REBUILD = "dl_index_rebuild_rate";
+const char* MT_RATE_TABLE_SCAN_DOCS = "dl_table_scan_rate";
+const char* MT_RATE_IDX_SCAN_DOCS = "dl_index_scan_rate";
 
 } // namespace DocLayerConstants

--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -78,5 +78,7 @@ const char* MT_HIST_TR_PER_REQUEST = "dl_tr_per_request";
 const char* MT_RATE_IDX_REBUILD = "dl_index_rebuild_rate";
 const char* MT_RATE_TABLE_SCAN_DOCS = "dl_table_scan_rate";
 const char* MT_RATE_IDX_SCAN_DOCS = "dl_index_scan_rate";
+const char* MT_GUAGE_CPU_PERCENTAGE = "dl_cpu_percentage";
+const char* MT_GUAGE_MEMORY_USAGE = "dl_memory_usage_bytes";
 
 } // namespace DocLayerConstants

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -91,6 +91,8 @@ extern const char* MT_HIST_TR_PER_REQUEST;
 extern const char* MT_RATE_IDX_REBUILD;
 extern const char* MT_RATE_TABLE_SCAN_DOCS;
 extern const char* MT_RATE_IDX_SCAN_DOCS;
+extern const char* MT_GUAGE_CPU_PERCENTAGE;
+extern const char* MT_GUAGE_MEMORY_USAGE;
 
 } // namespace DocLayerConstants
 

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -89,6 +89,8 @@ extern const char* MT_TIME_INSERT_LATENCY_US;
 extern const char* MT_HIST_INSERT_SZ;
 extern const char* MT_HIST_TR_PER_REQUEST;
 extern const char* MT_RATE_IDX_REBUILD;
+extern const char* MT_RATE_TABLE_SCAN_DOCS;
+extern const char* MT_RATE_IDX_SCAN_DOCS;
 
 } // namespace DocLayerConstants
 

--- a/src/DocLayer.actor.cpp
+++ b/src/DocLayer.actor.cpp
@@ -210,7 +210,8 @@ ACTOR Future<Void> extServerConnection(Reference<DocumentLayer> docLayer,
 	try {
 		try {
 			loop {
-				// Will be broken (or set or whatever) only when the memory we are passing to processRequest is no longer needed and can be popped
+				// Will be broken (or set or whatever) only when the memory we are passing to processRequest is no
+				// longer needed and can be popped
 				state Promise<Void> finished;
 				choose {
 					when(wait(onError)) {
@@ -472,7 +473,7 @@ ACTOR void publishProcessMetrics() {
 			DocumentLayer::metricReporter->captureGauge(DocLayerConstants::MT_GUAGE_MEMORY_USAGE,
 			                                            processMetrics.getInt64("Memory"));
 		};
-	} catch(...) {
+	} catch (...) {
 		TraceEvent("BD_processMetricsPublisherException");
 		throw;
 	}

--- a/src/QLPlan.actor.cpp
+++ b/src/QLPlan.actor.cpp
@@ -322,6 +322,7 @@ ACTOR static Future<Void> toDocInfo(PlanCheckpoint* checkpoint,
 	// Each key has a document ID as its last entry
 	state Key lastKey;
 	state FlowLock* outputLock = checkpoint->getDocumentFinishedLock();
+	state uint32_t nrDocs = 0;
 	try {
 		loop {
 			state KeyValue kv = waitNext(index_keys);
@@ -331,8 +332,11 @@ ACTOR static Future<Void> toDocInfo(PlanCheckpoint* checkpoint,
 			Standalone<StringRef> last(DataKey::decode_item_rev(kv.key, 0), kv.arena());
 			Reference<ScanReturnedContext> output(new ScanReturnedContext(base->getSubContext(last), scanID, lastKey));
 			dis.send(output);
+			nrDocs++;
 		}
+		DocumentLayer::metricReporter->captureMeter(DocLayerConstants::MT_RATE_IDX_SCAN_DOCS, nrDocs);
 	} catch (Error& e) {
+		DocumentLayer::metricReporter->captureMeter(DocLayerConstants::MT_RATE_IDX_SCAN_DOCS, nrDocs);
 		if (e.code() == error_code_actor_cancelled) {
 			if (checkpoint->splitBoundWanted())
 				checkpoint->splitBound(scanID) = keyAfter(lastKey);
@@ -527,6 +531,7 @@ ACTOR static Future<Void> doPKScan(PlanCheckpoint* checkpoint,
 	state FlowLock* outputLock = checkpoint->getDocumentFinishedLock();
 	state Standalone<StringRef> lastPK;
 	state Key lastKey;
+	state uint32_t nrDocs = 0;
 	try {
 		loop {
 			state KeyValue kv = waitNext(kvs);
@@ -538,12 +543,15 @@ ACTOR static Future<Void> doPKScan(PlanCheckpoint* checkpoint,
 				wait(outputLock->take());
 				output.send(Reference<ScanReturnedContext>(
 				    new ScanReturnedContext(cx->cx->getSubContext(lastPK), scanID, Key(kv.key, kv.arena()))));
+				nrDocs++;
 			}
 			// This needs to happen down here, so that we don't reset the split bound one later if we're cancelled while
 			// failing to get the lock.
 			lastKey = Key(kv.key, kv.arena());
 		}
+		DocumentLayer::metricReporter->captureMeter(DocLayerConstants::MT_RATE_TABLE_SCAN_DOCS, nrDocs);
 	} catch (Error& e) {
+		DocumentLayer::metricReporter->captureMeter(DocLayerConstants::MT_RATE_TABLE_SCAN_DOCS, nrDocs);
 		if (e.code() == error_code_actor_cancelled) {
 			if (checkpoint->splitBoundWanted()) {
 				DataKey splitKey = DataKey::decode_bytes(lastKey);

--- a/src/QLPlan.actor.cpp
+++ b/src/QLPlan.actor.cpp
@@ -334,7 +334,6 @@ ACTOR static Future<Void> toDocInfo(PlanCheckpoint* checkpoint,
 			dis.send(output);
 			nrDocs++;
 		}
-		DocumentLayer::metricReporter->captureMeter(DocLayerConstants::MT_RATE_IDX_SCAN_DOCS, nrDocs);
 	} catch (Error& e) {
 		DocumentLayer::metricReporter->captureMeter(DocLayerConstants::MT_RATE_IDX_SCAN_DOCS, nrDocs);
 		if (e.code() == error_code_actor_cancelled) {
@@ -549,7 +548,6 @@ ACTOR static Future<Void> doPKScan(PlanCheckpoint* checkpoint,
 			// failing to get the lock.
 			lastKey = Key(kv.key, kv.arena());
 		}
-		DocumentLayer::metricReporter->captureMeter(DocLayerConstants::MT_RATE_TABLE_SCAN_DOCS, nrDocs);
 	} catch (Error& e) {
 		DocumentLayer::metricReporter->captureMeter(DocLayerConstants::MT_RATE_TABLE_SCAN_DOCS, nrDocs);
 		if (e.code() == error_code_actor_cancelled) {


### PR DESCRIPTION
- Catching all types of connection errors.
- Added metrics on cpu and memory usage
- Added metrics on table/index scan
- Split long delay during cursor expiry into small ones to avoid stale `DelayedTask` on timer queue