### PR TITLE
Update FDB API version: 510 -> 610.

### DIFF
--- a/src/DocLayer.actor.cpp
+++ b/src/DocLayer.actor.cpp
@@ -505,7 +505,7 @@ ACTOR void setup(NetworkAddress na,
                  std::string fdbDatacenterID) {
 	state FDB::API* fdb;
 	try {
-		fdb = FDB::API::selectAPIVersion(510);
+		fdb = FDB::API::selectAPIVersion(610);
 		for (auto& knob : client_knobs)
 			fdb->setNetworkOption(FDBNetworkOption::FDB_NET_OPTION_KNOB, knob.first + "=" + knob.second);
 		for (auto& opt : client_network_options)


### PR DESCRIPTION
A bug in FDB broken multi-version client for versions bigger than 6.1 to use older API version. Investigation on FDB end is going on. Using higher API version avoids the problem and this patch is to do just that.