### PR TITLE
Resolves #156: The query parsing and validation part moved to the updateDocument constructor

### DIFF
--- a/src/ExtMsg.actor.h
+++ b/src/ExtMsg.actor.h
@@ -238,7 +238,6 @@ private:
 };
 
 Reference<Plan> planQuery(Reference<UnboundCollectionContext> cx, const bson::BSONObj& query);
-std::vector<std::string> staticValidateUpdateObject(bson::BSONObj update, bool multi, bool upsert);
 ACTOR Future<WriteCmdResult> attemptIndexInsertion(bson::BSONObj firstDoc,
                                                    Reference<ExtConnection> ec,
                                                    Reference<DocTransaction> tr,
@@ -256,9 +255,14 @@ ACTOR Future<WriteCmdResult> doUpdateCmd(Namespace ns,
                                          Reference<ExtConnection> ec);
 
 // FIXME: these don't really belong here either
-Reference<IUpdateOp> operatorUpdate(bson::BSONObj const& msgUpdate);
+Reference<IUpdateOp> operatorUpdate(Reference<UnboundCollectionContext> cx,
+                                    bson::BSONObj const& msgUpdate,
+                                    bool multi,
+                                    bool upsert);
 Reference<IUpdateOp> replaceUpdate(bson::BSONObj const& replaceWith);
 Reference<IInsertOp> simpleUpsert(bson::BSONObj const& selector, bson::BSONObj const& update);
-Reference<IInsertOp> operatorUpsert(bson::BSONObj const& selector, bson::BSONObj const& update);
+Reference<IInsertOp> operatorUpsert(Reference<UnboundCollectionContext> ucx,
+                                    bson::BSONObj const& selector,
+                                    bson::BSONObj const& update);
 
 #endif /* _EXT_MSG_ACTOR_H_ */

--- a/test/correctness/smoke/test_upsert.py
+++ b/test/correctness/smoke/test_upsert.py
@@ -401,6 +401,40 @@ updates = (
     },
 )
 
+#156: staticValidateUpdateObject function is moved to updateDocument constructor
+
+def test_upsert_exception_error_1(fixture_collection):
+    collection = fixture_collection
+
+    collection.delete_many({})
+
+    collection.insert_one({'_id':1, "B":[{'a':1}]})
+    #'_id' cannot be modified
+    #In case try to update '_id' it should throw an error
+    try:
+        collection.update_one({'_id':1}, {'$set': {'_id': 2}}, upsert=True)
+    except OperationFailure as e:
+        serverErrObj = e.details
+        assert serverErrObj['code'] != None
+        # 20010 : You may not modify '_id' in an update
+        assert serverErrObj['code'] == 20010, "Expected:20010, Found: {}".format(serverErrObj)
+
+
+def test_upsert_exception_error_2(fixture_collection):
+    collection = fixture_collection
+
+    collection.delete_many({})
+
+    collection.insert_one({'_id':1, "B":"qty"})
+    #'$rename' operator should not be empty
+    #In case '$rename' operator is empty it should throw an error
+    try:
+        collection.update_one({'_id':1}, {'$rename': {}}, upsert=True)
+    except OperationFailure as e:
+        serverErrObj = e.details
+        assert serverErrObj['code'] != None
+        # 26840 : Update operator has empty object for parameter. You must specify a field.
+        assert serverErrObj['code'] == 26840, "Expected:26840, Found: {}".format(serverErrObj)
 
 def operators_test_with_depth(dl_collection, depth):
     for update in updates:


### PR DESCRIPTION
This PR resolves [#156](https://github.com/FoundationDB/fdb-document-layer/issues/156)   

The query parsing and validating part are moved to the constructor of updateDocument. Added test cases to verify existing functionalities. 